### PR TITLE
Scripts for 3rd PRISMS-Fatigue manuscript

### DIFF
--- a/applications/README.md
+++ b/applications/README.md
@@ -7,7 +7,13 @@
   <B>Reference:</B> K. S. Stopka, M. Yaghoobi, J. E. Allison, and D. L. McDowell. Effects of boundary conditions on microstructure-sensitive fatigue crystal plasticity analysis. (in review).
   
   <B>Materials Commons Data set:</B> https://doi.org/10.13011/m3-mhgc-ec71
+
+
+## Effects of sample size and grain neighborhood
   
+  <B>Reference:</B> K. S. Stopka, M. Yaghoobi, J. E. Allison, and D. L. McDowell. Microstructure effects on the extreme value fatigue response of FCC metals and alloys: Effects of sample size and grain neighborhood. (in review).
+  
+  <B>Materials Commons Data set:</B> https://doi.org/10.13011/m3-31wm-h036
   
 
 ## Effects of grain size and grain shape

--- a/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_1st_highest_FIP_analysis.py
+++ b/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_1st_highest_FIP_analysis.py
@@ -1,0 +1,1958 @@
+import os
+import numpy as np
+import scipy.stats as ss
+import sklearn.metrics as sm
+import sys
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.pylab as plt_cols
+import matplotlib.cm as cm
+import scipy.ndimage.filters as filters
+import pandas as pd
+import matplotlib.ticker as ticker
+import operator
+import glob
+import pickle as p
+import scipy
+import re
+from statsmodels.distributions.empirical_distribution import ECDF
+import matplotlib.ticker as mtick
+import seaborn as sns
+from matplotlib.legend_handler import HandlerLineCollection, HandlerTuple
+
+# Get name of directory that contains the PRISMS-Fatigue scripts, i.e., this script
+DIR_LOC = os.path.dirname(os.path.abspath(__file__))
+
+# Define grain ID of the grain with the third highest FIP, indexed at 0.
+# This grain's information is therefore 556 in the FeatureData_FakeMatl_0.csv file
+grain_num_of_interest = 2423
+
+# Define where to store plots
+store_dirr = os.path.join(DIR_LOC, r'plots')
+
+# Define templates for FIP pickle files for the FS_FIP, normal stress, and plastic shear strain range
+file_name_template_master = ['sub_band_averaged_FS_FIP_pickle_%d.p', 'sub_band_averaged_normal_stress_pickle_%d.p', 'sub_band_averaged_plastic_shear_strain_range_pickle_%d.p']
+
+def read_FIPs_from_certain_grain(directory, file_name_template, num_inst):
+    # Additional unused function to read in the largest sub-band averaged FIPs (one per grain) from a single microstructure instantiation
+    # This is particularly useful when considering a very large SVE with more than ~10,000 grains as this function can take a long time!
+    # Go to directory
+    
+    tmp_dir = os.getcwd()
+    os.chdir(directory)
+    
+    # Specify name of pickle file with sub-band averaged FIPs
+    fname = file_name_template % num_inst    
+    
+
+    
+    # Initialize list of just FIPs
+    new_all_fs_fips = []
+
+    # Initialize list to keep track of which grains have already been considered
+    added_g = []
+    
+    # Read in FIPs
+    h1 = open(fname,'rb')
+    fips = p.load(h1)
+    h1.close()
+    
+    # Sort in descending order
+    sorted_fips = sorted(fips.items(), key=operator.itemgetter(1))
+    sorted_fips.reverse()
+    
+    # Specify how many of the highest FIPs per grain should be imported. Typically, only the few hundred highest FIPs are of interest
+    # This significantly speeds up this algorithm!
+    # IMPORTANT: If this is set below the number of grains in the instantiation, the function will fail! 
+    get_num_FIPs = len(sorted_fips)
+    
+    # Initialize array with more detailed FIP data
+    # FIP, grain number, slip system number, layer number, sub-band region number
+    all_data = np.zeros((get_num_FIPs,5))
+    
+    # Main counter
+    nn = 0
+    
+    # Track counter
+    mm = 0    
+
+    while len(added_g) < get_num_FIPs:
+    
+        if sorted_fips[nn][0][0] not in added_g:
+            added_g.append(sorted_fips[nn][0][0])
+            
+            all_data[mm][0] = sorted_fips[nn][1]
+            all_data[mm][1] = sorted_fips[nn][0][0]
+            all_data[mm][2] = sorted_fips[nn][0][1]
+            all_data[mm][3] = sorted_fips[nn][0][2]
+            all_data[mm][4] = sorted_fips[nn][0][3]
+            mm += 1
+            new_all_fs_fips.append(sorted_fips[nn][1])
+            # print(mm)
+        
+        if sorted_fips[nn][0][0] == grain_num_of_interest:
+            break
+            
+        nn += 1     
+    
+    os.chdir(tmp_dir)
+    # return new_all_fs_fips
+    return new_all_fs_fips, all_data[0:mm], added_g 
+
+def read_normal_stress_for_COV():
+    
+    # This function reads in the maximum normal stress in the grain of interest to calculate/plot coefficients of variation
+  
+    file_name_template = file_name_template_master[1]
+  
+    # 10
+    ''' Change largest NN in first layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_change_single_largest_neighbor_volume_orientation')
+    num_inst = 10
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_first_NN_new_FIPs = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_first_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_first_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_first_NN_new_FIPs.append(tt[0][0])
+
+    grain_with_new_largest_FIP_1st_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_1st_NN.append(tt[0])
+
+    # 5
+    ''' Change largest NN in second layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Change_single_largest_grain_in_2nd_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_second_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_second_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_second_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_second_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_2nd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_2nd_NN.append(tt[0])
+
+    # 5
+    ''' Change largest NN in third layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Change_single_largest_grain_in_3rd_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_third_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_third_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_third_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_third_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_3rd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_3rd_NN.append(tt[0])
+
+    # 5
+    ''' Change largest NN in fourth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Change_single_largest_grain_in_4th_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_fourth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_fourth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_fourth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_fourth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_4th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_4th_NN.append(tt[0])
+
+    # 5
+    ''' Change largest NN in fifth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Change_single_largest_grain_in_5th_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_fifth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_fifth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_fifth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_fifth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_5th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_5th_NN.append(tt[0])
+
+
+    # All the above still take place in grain 2424 (indexed at 1)
+
+
+
+
+
+
+
+
+
+
+
+    # 5
+    ''' Change ALL NN in first layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_different_first_neighbor_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_first_NN_new_FIPs = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_ALL_first_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_first_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_first_NN_new_FIPs.append(tt[0][0])
+
+    grain_with_new_largest_FIP_ALL_1st_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_1st_NN.append(tt[0])
+
+    # 5
+    ''' Change ALL NN in second layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_different_second_neighbor_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_second_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_second_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_second_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_second_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_2nd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_2nd_NN.append(tt[0])
+
+    # 5
+    ''' Change ALL NN in third layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_different_3rd_neighbor_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_third_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_third_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_third_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_third_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_3rd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_3rd_NN.append(tt[0])
+
+    # 5
+    ''' Change ALL NN in fourth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_different_4th_neighbor_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_fourth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_fourth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_fourth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_fourth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_4th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_4th_NN.append(tt[0])
+
+    # 5
+    ''' Change ALL NN in fifth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_different_5th_neighbor_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_fifth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_fifth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_fifth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_fifth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_5th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_5th_NN.append(tt[0])
+
+
+
+
+
+    # 10
+    ''' Change NN with most shared area in first layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_change_single_largest_neighbor_shared_area_orientation')
+    num_inst = 10
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_first_NN_most_shared_area = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_first_NN_most_shared_area.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_first_NN_most_shared_area_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_first_NN_most_shared_area_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_1st_NN_most_shared_area = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_1st_NN_most_shared_area.append(tt[0])
+
+
+    # 1
+    ''' COMPARE TO ORIGINAL FROM 250^3 '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_to_72_72_72_original_orientations')
+    num_inst = 1
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_original = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_original.append(total_all_data[ii].transpose()[0][kk])
+
+    new_original_FIPs = []
+    for tt in total_all_data:
+        new_original_FIPs.append(tt[0][0])
+
+
+    oringial_FIP_same_orientation = []
+    for tt in total_added_g:
+        oringial_FIP_same_orientation.append(tt[0])
+
+
+    # All cases above have largest FIP in grain 2424.
+
+
+
+    # NOTE: Highest FIPs when changing a SINGLE nearest neighbor in all five layers remains in grain 2424
+    #       Highest FIPs when changing ALL nearest neighbors in first and second layer is now 1567, whereas it is 2424 when changing all third, fourth, and fifth NN orientations!
+    #       The last five all occur in 2424!
+
+
+    # https://towardsdatascience.com/scattered-boxplots-graphing-experimental-results-with-matplotlib-seaborn-and-pandas-81f9fa8a1801
+
+    dataset1 = [grain_2424_change_first_NN_most_shared_area, 
+                grain_2424_change_first_NN_new_FIPs, grain_2424_change_second_NN_new_FIPs, grain_2424_change_third_NN_new_FIPs, grain_2424_change_fourth_NN_new_FIPs, grain_2424_change_fifth_NN_new_FIPs, 
+                grain_2424_change_ALL_first_NN_new_FIPs, grain_2424_change_ALL_second_NN_new_FIPs, grain_2424_change_ALL_third_NN_new_FIPs, grain_2424_change_ALL_fourth_NN_new_FIPs, grain_2424_change_ALL_fifth_NN_new_FIPs, grain_2424_original]
+
+
+    fname = '1st_highest_normal_stress_variation_first_plot_data.p'
+    h1 = open(os.path.join(store_dirr, fname), 'wb')
+    p.dump(dataset1, h1)
+    h1.close()
+    
+    return dataset1
+   
+def read_and_plot_main_FIP_PSSR(file_name_template, type_plot):
+    # This function will read in the FIPs to create the first plot for the grain that manifests the 1st highest FIP in the 160,000 grain microstructure
+  
+    # 10
+    ''' Change largest NN in first layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_change_single_largest_neighbor_volume_orientation')
+    num_inst = 10
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_first_NN_new_FIPs = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_first_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_first_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_first_NN_new_FIPs.append(tt[0][0])
+
+    grain_with_new_largest_FIP_1st_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_1st_NN.append(tt[0])
+
+    # 5
+    ''' Change largest NN in second layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Change_single_largest_grain_in_2nd_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_second_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_second_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_second_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_second_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_2nd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_2nd_NN.append(tt[0])
+
+    # 5
+    ''' Change largest NN in third layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Change_single_largest_grain_in_3rd_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_third_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_third_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_third_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_third_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_3rd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_3rd_NN.append(tt[0])
+
+    # 5
+    ''' Change largest NN in fourth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Change_single_largest_grain_in_4th_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_fourth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_fourth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_fourth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_fourth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_4th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_4th_NN.append(tt[0])
+
+    # 5
+    ''' Change largest NN in fifth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Change_single_largest_grain_in_5th_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_fifth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_fifth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_fifth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_fifth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_5th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_5th_NN.append(tt[0])
+
+
+    # All the above still take place in grain 2424 (indexed at 1)
+
+
+
+
+
+
+
+
+
+
+
+    # 5
+    ''' Change ALL NN in first layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_different_first_neighbor_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_first_NN_new_FIPs = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_ALL_first_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_first_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_first_NN_new_FIPs.append(tt[0][0])
+
+    grain_with_new_largest_FIP_ALL_1st_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_1st_NN.append(tt[0])
+
+    # 5
+    ''' Change ALL NN in second layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_different_second_neighbor_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_second_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_second_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_second_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_second_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_2nd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_2nd_NN.append(tt[0])
+
+    # 5
+    ''' Change ALL NN in third layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_different_3rd_neighbor_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_third_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_third_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_third_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_third_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_3rd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_3rd_NN.append(tt[0])
+
+    # 5
+    ''' Change ALL NN in fourth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_different_4th_neighbor_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_fourth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_fourth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_fourth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_fourth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_4th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_4th_NN.append(tt[0])
+
+    # 5
+    ''' Change ALL NN in fifth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_different_5th_neighbor_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_fifth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_fifth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_fifth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_fifth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_5th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_5th_NN.append(tt[0])
+
+
+    # The first two cases above have highest FS_FIP in grain number 1566 (indexed at 1); the last three are back at 2424.
+
+    # The first two cases above have highest PSSR in grain number 3968 (indexed at 1); the last three are back at 2424.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    # 10
+    ''' Change NN with most shared area in first layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_change_single_largest_neighbor_shared_area_orientation')
+    num_inst = 10
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_first_NN_most_shared_area = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_first_NN_most_shared_area.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_first_NN_most_shared_area_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_first_NN_most_shared_area_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_1st_NN_most_shared_area = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_1st_NN_most_shared_area.append(tt[0])
+
+
+    # 1
+    ''' Largest NN has same orientation '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_largest_neighbor_has_same_orientation')
+    num_inst = 1
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_largest_NN_same_orientation = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_largest_NN_same_orientation.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_NN_same_orientation_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_NN_same_orientation_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_NN_same_orientation = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_NN_same_orientation.append(tt[0])
+
+    # 1
+    ''' NN with most shared surface area has same orientation '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_72_72_72_neighbor_with_most_shared_area_has_same_orientation')
+    num_inst = 1
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_most_shared_area_NN_same_orientation = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_most_shared_area_NN_same_orientation.append(total_all_data[ii].transpose()[0][kk])
+
+    new_most_shared_area_NN_same_orientation_new_FIPs = []
+    for tt in total_all_data:
+        new_most_shared_area_NN_same_orientation_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_most_shared_area_FIP_NN_same_orientation = []
+    for tt in total_added_g:
+        grain_with_new_most_shared_area_FIP_NN_same_orientation.append(tt[0])
+
+    # 1
+    ''' COMPARE TO ORIGINAL FROM 250^3 '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_to_72_72_72_original_orientations')
+    num_inst = 1
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_original = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_original.append(total_all_data[ii].transpose()[0][kk])
+
+    new_original_FIPs = []
+    for tt in total_all_data:
+        new_original_FIPs.append(tt[0][0])
+
+
+    oringial_FIP_same_orientation = []
+    for tt in total_added_g:
+        oringial_FIP_same_orientation.append(tt[0])
+
+
+    # All cases above have largest FIP in grain 2424.
+
+
+
+    # NOTE: Highest FIPs when changing a SINGLE nearest neighbor in all five layers remains in grain 2424
+    #       Highest FIPs when changing ALL nearest neighbors in first and second layer is now 1567, whereas it is 2424 when changing all third, fourth, and fifth NN orientations!
+    #       The last five all occur in 2424!
+
+
+    # https://towardsdatascience.com/scattered-boxplots-graphing-experimental-results-with-matplotlib-seaborn-and-pandas-81f9fa8a1801
+
+    dataset1 = [grain_2424_change_first_NN_most_shared_area, 
+                new_largest_first_NN_new_FIPs, new_largest_second_NN_new_FIPs, new_largest_third_NN_new_FIPs, new_largest_fourth_NN_new_FIPs, new_largest_fifth_NN_new_FIPs, 
+                grain_2424_change_ALL_first_NN_new_FIPs, grain_2424_change_ALL_second_NN_new_FIPs, new_largest_ALL_third_NN_new_FIPs, new_largest_ALL_fourth_NN_new_FIPs, new_largest_ALL_fifth_NN_new_FIPs,
+                grain_2424_largest_NN_same_orientation, grain_2424_most_shared_area_NN_same_orientation]
+
+
+    names1 = ['$1^{st}$ NN with most SA', 
+              'Largest $1^{st}$ NN','Largest $2^{nd}$ NN', 'Largest $3^{rd}$ NN', 'Largest $4^{th}$ NN', 'Largest $5^{th}$ NN', 
+              'All 13 $1^{st}$ NNs','All 68 $2^{nd}$ NNs', 'All 159 $3^{rd}$ NNs', 'All 303 $4^{th}$ NNs', 'All 517 $5^{th}$ NNs',
+              'Largest $1^{st}$ NN, same ori', '$1^{st}$ NN with most SA, same ori']
+
+    vals, names, xs = [],[],[]
+
+    for i, col in enumerate(names1):
+        vals.append(dataset1[i])
+        names.append(col)
+        xs.append(np.random.normal(i + 1, 0.04, len(dataset1[i])))  # adds jitter to the data points - can be adjusted
+
+
+    dataset2 = [new_largest_ALL_first_NN_new_FIPs, new_largest_ALL_second_NN_new_FIPs]
+    vals_1, xs_1 = [], []
+
+    for kk in range(2):
+        vals_1.append(dataset2[kk])
+        xs_1.append(np.random.normal(kk + 7, 0.04, len(dataset2[kk])))  # adds jitter to the data points - can be adjusted
+        
+    # Store plotting data in pickle file!
+
+    if type_plot == 'FS_FIP':
+        fname = '1st_highest_FS_FIP_variation_first_plot_data.p'
+    elif type_plot == 'PSSR':
+        fname = '1st_highest_PSSR_variation_first_plot_data.p'
+    h1 = open(os.path.join(store_dirr, fname), 'wb')
+    p.dump([dataset1, dataset2, names1], h1)
+    h1.close()
+
+    fontsizee = 7
+
+    fig = plt.figure(facecolor="white", figsize=(7.5, 5), dpi=1200)
+    plt.rcParams["mathtext.default"] = "regular"
+    plt.boxplot(vals[0:11]+[1,1], labels=names, zorder = 1, showfliers=False)
+
+
+    # palette = ['g'] * 5 + ['b'] * 5 + ['m'] * 1 + ['c'] * 2
+    palette = ['m'] * 1 + ['g'] * 5 + ['b'] * 5 + ['c'] * 2
+    markers = ['D'] * 1 + ['o'] * 5 + ['^'] * 5 + ['s'] * 2
+
+    for x, val, c, m in zip(xs, vals, palette, markers):
+        plt.scatter(x, val, alpha=0.5, color = c, zorder = 2, marker = m)
+        
+    if type_plot == 'FS_FIP':
+        plt.plot((0,16),(new_original_FIPs,new_original_FIPs), linestyle = '--', c = 'k', linewidth=1.0, zorder = 1, label = 'Maximum FS FIP in unaltered $72^{3}$ microstructure')
+    else:
+        plt.plot((0,16),(new_original_FIPs,new_original_FIPs), linestyle = '--', c = 'k', linewidth=1.0, zorder = 1, label = 'Maximum PSSR in unaltered $72^{3}$ microstructure')
+
+    # Star markers for largest FIP in entire 1st NN results
+    p1 = plt.scatter(xs_1[0], vals_1[0], alpha=0.65, marker = '^', color = 'r', s = 25, label = 'Largest in entire microstructure, not in GOI')
+
+    # Star markers for largest FIP in entire 1st NN results
+    p2 = plt.scatter(xs_1[1], vals_1[1], alpha=0.65, marker = '^', color = 'r', s = 25)
+
+    # l = plt.legend([(p1, p2)], ['Largest FIPs in microstructure'], numpoints=1, fontsize = 6, loc = 'upper right', handler_map={tuple: HandlerTuple(ndivide=None)})
+
+    plt.legend(framealpha = 1, loc = 'lower left', fontsize = fontsizee)
+    plt.ticklabel_format(style = 'sci', axis='y', scilimits=(0,0), useMathText = True)
+
+
+
+    if type_plot == 'FS_FIP':
+        plt.ylim(0.0036, 0.014)
+    elif type_plot == 'PSSR':
+        plt.ylim(0.00058, 0.00222)
+    plt.xlim(0.5,13.5)
+    
+    if type_plot == 'FS_FIP':
+        plt.ylabel('Largest sub-band averaged FS FIP in grain 2424')
+    elif type_plot == 'PSSR':
+        plt.ylabel('Largest sub-band averaged PSSR in grain 2424')
+    plt.xlabel('Altered grain orientations')    
+    plt.grid(True, zorder = 1, axis = 'y', alpha = 0.4)
+    plt.xticks(rotation = 30, fontsize = fontsizee)
+    plt.tight_layout()
+    
+    if type_plot == 'FS_FIP':
+        plt.savefig(os.path.join(store_dirr, '1st_highest_FS_FIP_variation_first_plot'))
+    elif type_plot == 'PSSR':
+        plt.savefig(os.path.join(store_dirr, '1st_highest_PSSR_variation_first_plot'))
+    plt.close()
+
+def plot_COVs():
+    # Function to plot coefficient of variation for the FS_FIP, PSSR, and maximum normal stresses
+
+    
+    ''' Read in previously written data for FS FIP '''
+    
+    fname = '1st_highest_FS_FIP_variation_first_plot_data.p'
+    h1 = open(os.path.join(store_dirr, fname), 'rb')
+    FS_FIP_dataset1, FS_FIP_dataset2, FS_FIP_names1 = p.load(h1)
+    h1.close()
+    
+    FS_FIP_COVs = np.zeros(11)
+    
+    for qqq in range(11):
+        FS_FIP_COVs[qqq] = scipy.stats.variation(FS_FIP_dataset1[qqq]) * 100
+
+
+
+    ''' Read in previously written data for PSSR '''
+    
+    fname = '1st_highest_PSSR_variation_first_plot_data.p'
+    h1 = open(os.path.join(store_dirr, fname), 'rb')
+    PSSR_dataset1, PSSR_dataset2, PSSR_names1 = p.load(h1)
+    h1.close()
+
+    
+    PSSR_COVs = np.zeros(11)
+    
+    for qqq in range(11):
+        PSSR_COVs[qqq] = scipy.stats.variation(PSSR_dataset1[qqq]) * 100
+
+
+
+    ''' Read in previously written data or compile data for normal stress '''
+    
+    fname = '1st_highest_normal_stress_variation_first_plot_data.p'
+    
+    if os.path.exists(os.path.join(store_dirr, fname)):
+        h1 = open(os.path.join(store_dirr, fname), 'rb')
+        normal_stress_dataset1 = p.load(h1)
+        h1.close()
+    else:
+        normal_stress_dataset1 = read_normal_stress_for_COV()
+
+    
+    normal_stress_COVs = np.zeros(11)
+    
+    for qqq in range(11):
+        normal_stress_COVs[qqq] = scipy.stats.variation(normal_stress_dataset1[qqq]) * 100
+
+
+
+    # Plot COVs
+
+    # covs = np.zeros(11)
+
+    # for qqq in range(11):
+    #     covs[qqq] = scipy.stats.variation(dataset1[qqq])
+        
+
+    # sigma_COV = [0.56, 0.34, 0.16, 0.21, 0.02, 0.00, 1.89, 0.88, 0.61, 0.13, 0.21]
+    # FIP_COV   = [7.96, 7.60, 0.86, 1.78, 0.08, 0.21, 4.62, 2.40, 7.55, 7.17, 2.49]
+    # PSSR_COV  = [7.50, 6.45, 0.89, 1.85, 0.08, 0.21, 8.05, 1.33, 7.31, 7.23, 2.39]
+
+    all_COV = [PSSR_COVs, normal_stress_COVs, FS_FIP_COVs]
+    all_COV_t = np.transpose(all_COV)
+
+    names1 = ['$1^{st}$ NN with most SA', 
+              'Largest $1^{st}$ NN','Largest $2^{nd}$ NN', 'Largest $3^{rd}$ NN', 'Largest $4^{th}$ NN', 'Largest $5^{th}$ NN', 
+              'All 13 $1^{st}$ NNs','All 68 $2^{nd}$ NNs', 'All 159 $3^{rd}$ NNs', 'All 303 $4^{th}$ NNs', 'All 517 $5^{th}$ NNs']
+
+    fontsizee = 7
+
+
+    fig = plt.figure(facecolor="white", figsize=(5, 4), dpi=1200)
+    plt.rcParams["mathtext.default"] = "regular"
+
+    plt_labels = ['PSSR', r"$\sigma_n$", 'FIP']
+    markers = ['s', 'o', '^']
+    colors = ['g', 'm', 'b']
+
+    for ii in range(3):
+        plt.scatter(range(1, 12), all_COV[ii], label = plt_labels[ii], zorder = 2, c = colors[ii], marker = markers[ii])
+
+    # plt.plot((1.5,1.5), (-1,10), linestyle = '--', c = 'k', linewidth = 0.45)
+    # plt.plot((6.5,6.5), (-1,10), linestyle = '--', c = 'k', linewidth = 0.45)
+
+    plt.legend(framealpha = 1)
+    plt.ticklabel_format(style = 'sci', axis='y', scilimits=(0,0), useMathText = True)
+
+    # plt.ylim(-0.35, 8.4)
+    plt.ylabel('Coefficient of Variation [%]')    
+    plt.xlabel('Altered grain orientations')    
+    plt.grid(True, zorder = 1, axis = 'y', alpha = 0.4)
+    plt.xticks(range(1, 12), labels = names1, rotation = 30, fontsize = 6)
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, '1st_highest_GOI_coef_of_variation'))
+    plt.close()
+
+def read_and_plot_secondary_FIPs(file_name_template):
+    # This function will read in the FIPs to create the second plot for the grain that manifests the 1st highest FIP in the 160,000 grain microstructure
+
+    # 5
+    ''' Change 5 in 3rd layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Layer3_Largest_5_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_in_layer_3 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_in_layer_3.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_in_layer_3 = []
+    for tt in total_all_data:
+        new_largest_change_5_in_layer_3.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_in_layer_3 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_5_in_layer_3.append(tt[0])
+
+    # 5
+    ''' Change 5% in 3rd layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Layer3_Largest_5Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_perc_in_layer_3 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_perc_in_layer_3.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_perc_in_layer_3 = []
+    for tt in total_all_data:
+        new_largest_change_5_perc_in_layer_3.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_perc_in_layer_3 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_5_perc_in_layer_3.append(tt[0])
+
+    # 5
+    ''' Change 20% in 3rd layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Layer3_Largest_20Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_20_perc_in_layer_3 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_20_perc_in_layer_3.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_20_perc_in_layer_3 = []
+    for tt in total_all_data:
+        new_largest_change_20_perc_in_layer_3.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_20_perc_in_layer_3 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_20_perc_in_layer_3.append(tt[0])
+
+    # 5
+    ''' Change 5 in 4th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Layer4_Largest_5_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_in_layer_4 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_in_layer_4.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_in_layer_4 = []
+    for tt in total_all_data:
+        new_largest_change_5_in_layer_4.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_in_layer_4 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_5_in_layer_4.append(tt[0])
+
+    # 5
+    ''' Change 5% in 4th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Layer4_Largest_5Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_perc_in_layer_4 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_perc_in_layer_4.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_perc_in_layer_4 = []
+    for tt in total_all_data:
+        new_largest_change_5_perc_in_layer_4.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_perc_in_layer_4 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_5_perc_in_layer_4.append(tt[0])
+
+    # 5
+    ''' Change 20% in 4th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Layer4_Largest_20Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_20_perc_in_layer_4 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_20_perc_in_layer_4.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_20_perc_in_layer_4 = []
+    for tt in total_all_data:
+        new_largest_change_20_perc_in_layer_4.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_20_perc_in_layer_4 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_20_perc_in_layer_4.append(tt[0])
+    
+    # 5
+    ''' Change 5 in 5th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Layer5_Largest_5_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_in_layer_5 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_in_layer_5.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_in_layer_5 = []
+    for tt in total_all_data:
+        new_largest_change_5_in_layer_5.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_in_layer_5 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_5_in_layer_5.append(tt[0])
+
+    # 5
+    ''' Change 5% in 5th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Layer5_Largest_5Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_perc_in_layer_5 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_perc_in_layer_5.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_perc_in_layer_5 = []
+    for tt in total_all_data:
+        new_largest_change_5_perc_in_layer_5.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_perc_in_layer_5 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_5_perc_in_layer_5.append(tt[0])
+
+    # 5
+    ''' Change 20% in 5th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\Layer5_Largest_20Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_20_perc_in_layer_5 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_20_perc_in_layer_5.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_20_perc_in_layer_5 = []
+    for tt in total_all_data:
+        new_largest_change_20_perc_in_layer_5.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_20_perc_in_layer_5 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_20_perc_in_layer_5.append(tt[0])
+
+
+    # 1
+    ''' COMPARE TO ORIGINAL FROM 250^3 '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\data\cropped_to_72_72_72_original_orientations')
+    num_inst = 1
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, file_name_template, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_original = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_original.append(total_all_data[ii].transpose()[0][kk])
+
+    new_original_FIPs = []
+    for tt in total_all_data:
+        new_original_FIPs.append(tt[0][0])
+
+
+
+
+    # https://towardsdatascience.com/scattered-boxplots-graphing-experimental-results-with-matplotlib-seaborn-and-pandas-81f9fa8a1801
+
+
+    dataset1 = [grain_2424_change_5_in_layer_3, grain_2424_change_5_in_layer_4, grain_2424_change_5_in_layer_5,
+                grain_2424_change_5_perc_in_layer_3, grain_2424_change_5_perc_in_layer_4, grain_2424_change_5_perc_in_layer_5,
+                grain_2424_change_20_perc_in_layer_3, grain_2424_change_20_perc_in_layer_4, grain_2424_change_20_perc_in_layer_5]
+
+    names1 = ['Largest 5 in $3^{rd}$ layer',   'Largest 5 in $4^{th}$ layer',   'Largest 5 in $5^{th}$ layer',
+              'Largest 5% in $3^{rd}$ layer',  'Largest 5% in $4^{th}$ layer',  'Largest 5% in $5^{th}$ layer',
+              'Largest 20% in $3^{rd}$ layer', 'Largest 20% in $4^{th}$ layer', 'Largest 20% in $5^{th}$ layer']
+
+
+    vals, names, xs = [],[],[]
+
+    for i, col in enumerate(names1):
+        vals.append(dataset1[i])
+        names.append(col)
+        xs.append(np.random.normal(i + 1, 0.04, len(dataset1[i])))  # adds jitter to the data points - can be adjusted
+
+
+    # dataset2 = [new_largest_ALL_first_NN_new_FIPs, new_largest_ALL_second_NN_new_FIPs]
+    # vals_1, xs_1 = [], []
+
+    # for kk in range(2):
+    #     vals_1.append(dataset2[kk])
+    #     xs_1.append(np.random.normal(kk + 7, 0.04, len(dataset2[kk])))  # adds jitter to the data points - can be adjusted
+        
+        
+    # Store FIPs pickle file!
+
+    fname = '1st_highest_FS_FIP_variation_second_plot_data.p'
+    h1 = open(os.path.join(store_dirr, fname), 'wb')
+    p.dump([dataset1, names1], h1)
+    h1.close()
+
+
+    fontsizee = 7
+
+    fig = plt.figure(facecolor="white", figsize=(7.5, 4.5), dpi=1200)
+    plt.rcParams["mathtext.default"] = "regular"
+    plt.boxplot(vals[0:9], labels=names, zorder = 1, showfliers=False)
+
+
+    # palette = ['g'] * 5 + ['b'] * 5 + ['m'] * 1 + ['c'] * 2
+    # palette = ['m'] * 1 + ['g'] * 5 + ['b'] * 5 + ['c'] * 2
+    markers = ['p'] * 3 + ['d'] * 3 + ['*'] * 3
+    palette = ['darkmagenta', 'crimson', 'deepskyblue', 'darkmagenta', 'crimson', 'deepskyblue', 'darkmagenta', 'crimson', 'deepskyblue']
+    palette = ['m', 'r', 'b', 'm', 'r', 'b', 'm', 'r', 'b']
+
+    for x, val, c, m in zip(xs, vals, palette, markers):
+        plt.scatter(x, val, alpha=0.55, color = c, zorder = 2, marker = m)
+        
+    plt.plot((0,16),(new_original_FIPs,new_original_FIPs), linestyle = '--', c = 'k', linewidth=1.0, zorder = 1, label = 'Maximum FIP in unaltered $72^{3}$ microstructure')
+
+    # Star markers for largest FIP in entire 1st NN results
+    # p1 = plt.scatter(xs_1[0], vals_1[0], alpha=0.65, marker = '^', color = 'r', s = 25, label = 'Largest in entire microstructure, not in GOI')
+
+    # Star markers for largest FIP in entire 1st NN results
+    # p2 = plt.scatter(xs_1[1], vals_1[1], alpha=0.65, marker = '^', color = 'r', s = 25)
+
+    # l = plt.legend([(p1, p2)], ['Largest FIPs in microstructure'], numpoints=1, fontsize = 6, loc = 'upper right', handler_map={tuple: HandlerTuple(ndivide=None)})
+
+    plt.legend(framealpha = 1, loc = 'lower left', fontsize = fontsizee)
+
+    plt.yticks(np.arange(1.1e-2, 1.3e-2, 0.3e-3))
+
+    plt.ticklabel_format(style = 'sci', axis='y', scilimits=(0,0), useMathText = True)
+
+    # plt.ylim(0.0036, 0.014)
+    plt.ylim(0.011, 0.013)
+    plt.xlim(0.5,9.5)
+
+    plt.ylabel('Largest sub-band averaged FS FIP in grain 2424')    
+    plt.xlabel('Altered grain orientations')    
+    plt.grid(True, zorder = 1, axis = 'y', alpha = 0.4)
+    plt.xticks(rotation = 30, fontsize = fontsizee)
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, '1st_highest_FS_FIP_variation_second_plot'))
+    plt.close()
+
+def main():
+    # Plot variation in FIPs; first plot
+    read_and_plot_main_FIP_PSSR(file_name_template_master[0], 'FS_FIP')
+    
+    # Plot variation in Plastic shear strain range; first plot
+    read_and_plot_main_FIP_PSSR(file_name_template_master[2], 'PSSR')
+
+    # Plot variation in FIPs; second plot
+    read_and_plot_secondary_FIPs(file_name_template_master[0])
+    
+    # Plot coefficient of variation
+    plot_COVs()
+
+if __name__ == "__main__":
+    main()

--- a/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_3rd_highest_FIP_analysis.py
+++ b/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_3rd_highest_FIP_analysis.py
@@ -1,0 +1,1351 @@
+import os
+import numpy as np
+import scipy.stats as ss
+import sklearn.metrics as sm
+import sys
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.pylab as plt_cols
+import matplotlib.cm as cm
+import scipy.ndimage.filters as filters
+import pandas as pd
+import matplotlib.ticker as ticker
+import operator
+import glob
+import pickle as p
+import scipy
+import re
+from statsmodels.distributions.empirical_distribution import ECDF
+import matplotlib.ticker as mtick
+import seaborn as sns
+from matplotlib.legend_handler import HandlerLineCollection, HandlerTuple
+
+# Get name of directory that contains the PRISMS-Fatigue scripts, i.e., this script
+DIR_LOC = os.path.dirname(os.path.abspath(__file__))
+
+# Define grain ID of the grain with the third highest FIP, indexed at 0.
+# This grain's information is therefore 556 in the FeatureData_FakeMatl_0.csv file
+grain_num_of_interest = 555
+
+# Define where to store plots
+store_dirr = os.path.join(DIR_LOC, r'plots')
+
+def read_FIPs_from_certain_grain(directory, num_inst):
+    # Additional unused function to read in the largest sub-band averaged FIPs (one per grain) from a single microstructure instantiation
+    # This is particularly useful when considering a very large SVE with more than ~10,000 grains as this function can take a long time!
+    # Go to directory
+    
+    tmp_dir = os.getcwd()
+    os.chdir(directory)
+    
+    # Specify name of pickle file with sub-band averaged FIPs
+    fname = 'sub_band_averaged_FS_FIP_pickle_%d.p' % num_inst    
+    
+    # Specify how many of the highest FIPs per grain should be imported. Typically, only the few hundred highest FIPs are of interest
+    # This significantly speeds up this algorithm!
+    # IMPORTANT: If this is set below the number of grains in the instantiation, the function will fail! 
+    get_num_FIPs = 2500
+    
+    # Initialize list of just FIPs
+    new_all_fs_fips = []
+
+    # Initialize list to keep track of which grains have already been considered
+    added_g = []
+    
+    # Read in FIPs
+    h1 = open(fname,'rb')
+    fips = p.load(h1)
+    h1.close()
+    
+    # Sort in descending order
+    sorted_fips = sorted(fips.items(), key=operator.itemgetter(1))
+    sorted_fips.reverse()
+    
+    # Initialize array with more detailed FIP data
+    # FIP, grain number, slip system number, layer number, sub-band region number
+    all_data = np.zeros((get_num_FIPs,5))
+    
+    # Main counter
+    nn = 0
+    
+    # Track counter
+    mm = 0    
+    
+    while len(added_g) < get_num_FIPs:
+    
+        if sorted_fips[nn][0][0] not in added_g:
+            added_g.append(sorted_fips[nn][0][0])
+            
+            all_data[mm][0] = sorted_fips[nn][1]
+            all_data[mm][1] = sorted_fips[nn][0][0]
+            all_data[mm][2] = sorted_fips[nn][0][1]
+            all_data[mm][3] = sorted_fips[nn][0][2]
+            all_data[mm][4] = sorted_fips[nn][0][3]
+            mm += 1
+            new_all_fs_fips.append(sorted_fips[nn][1])
+            # print(mm)
+        
+        if sorted_fips[nn][0][0] == grain_num_of_interest:
+            break
+            
+        nn += 1     
+    
+    os.chdir(tmp_dir)
+    # return new_all_fs_fips
+    return new_all_fs_fips, all_data[0:mm], added_g 
+
+def read_and_plot_main_FIPs():
+    # This function will read in the FIPs to create the first plot for the grain that manifests the 3rd highest FIP in the 160,000 grain microstructure
+
+    # 10
+    ''' Change largest NN in first layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\change_orientation_of_largest_grain_in_1st_layer')
+    num_inst = 10
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_first_NN_new_FIPs = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_first_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_first_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_first_NN_new_FIPs.append(tt[0][0])
+
+    grain_with_new_largest_FIP_1st_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_1st_NN.append(tt[0])
+
+    if grain_2424_change_first_NN_new_FIPs != new_largest_first_NN_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # 5
+    ''' Change largest NN in second layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\change_orientation_of_largest_grain_in_2nd_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_second_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_second_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_second_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_second_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_2nd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_2nd_NN.append(tt[0])
+
+    if grain_2424_change_second_NN_new_FIPs != new_largest_second_NN_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # 5
+    ''' Change largest NN in third layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\change_orientation_of_largest_grain_in_3rd_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_third_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_third_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_third_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_third_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_3rd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_3rd_NN.append(tt[0])
+
+    if grain_2424_change_third_NN_new_FIPs != new_largest_third_NN_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # 5
+    ''' Change largest NN in fourth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\change_orientation_of_largest_grain_in_4th_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_fourth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_fourth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_fourth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_fourth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_4th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_4th_NN.append(tt[0])
+
+    if grain_2424_change_fourth_NN_new_FIPs != new_largest_fourth_NN_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # 5
+    ''' Change largest NN in fifth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\change_orientation_of_largest_grain_in_5th_layer')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_fifth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_fifth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_fifth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_fifth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_5th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_5th_NN.append(tt[0])
+
+    if grain_2424_change_fifth_NN_new_FIPs != new_largest_fifth_NN_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # ---> All largest PSSR in grain 556 (indexed at 1). 
+
+
+
+
+
+
+
+
+
+
+    # 5
+    ''' Change ALL NN in first layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\change_all_1st_layer_grain_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_first_NN_new_FIPs = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_ALL_first_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_first_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_first_NN_new_FIPs.append(tt[0][0])
+
+    grain_with_new_largest_FIP_ALL_1st_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_1st_NN.append(tt[0])
+
+    if grain_2424_change_ALL_first_NN_new_FIPs != new_largest_ALL_first_NN_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # 5
+    ''' Change ALL NN in second layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\change_all_2nd_layer_grain_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_second_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_second_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_second_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_second_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_2nd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_2nd_NN.append(tt[0])
+
+    if grain_2424_change_ALL_second_NN_new_FIPs != new_largest_ALL_second_NN_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # 5
+    ''' Change ALL NN in third layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\change_all_3rd_layer_grain_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_third_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_third_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_third_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_third_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_3rd_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_3rd_NN.append(tt[0])
+
+    if grain_2424_change_ALL_third_NN_new_FIPs != new_largest_ALL_third_NN_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # 5
+    ''' Change ALL NN in fourth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\change_all_4th_layer_grain_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_fourth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_fourth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_fourth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_fourth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_4th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_4th_NN.append(tt[0])
+
+    if grain_2424_change_ALL_fourth_NN_new_FIPs != new_largest_ALL_fourth_NN_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # 5
+    ''' Change ALL NN in fifth layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\change_all_5th_layer_grain_orientations')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_ALL_fifth_NN_new_FIPs = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_ALL_fifth_NN_new_FIPs.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_ALL_fifth_NN_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_ALL_fifth_NN_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_ALL_5th_NN = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_ALL_5th_NN.append(tt[0])
+
+    if grain_2424_change_ALL_fifth_NN_new_FIPs != new_largest_ALL_fifth_NN_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # When all orientations are changed in FIRST layer, the highest FIP now occurs in grain number 2625, see variable "grain_with_new_largest_FIP_ALL_1st_NN"
+    # When all orientations are changed in THIRD layer, the highest FIP now occurs in grain number 93 FOR THE THIRD OUT OF FIVE GRAIN ALTERATIONS, see variable "grain_with_new_largest_FIP_ALL_3rd_NN"
+
+
+
+
+
+
+
+
+    # 10
+    ''' Change NN with most shared area in first layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\change_orientation_that_shares_most_surface_area_in_1st_layer')
+    num_inst = 10
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_first_NN_most_shared_area = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_change_first_NN_most_shared_area.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_first_NN_most_shared_area_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_first_NN_most_shared_area_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_1st_NN_most_shared_area = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_1st_NN_most_shared_area.append(tt[0])
+
+    if grain_2424_change_first_NN_most_shared_area != new_largest_first_NN_most_shared_area_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # 1
+    ''' Largest NN has same orientation '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\largest_neighbor_has_same_orientation_as_GOI')
+    num_inst = 1
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_largest_NN_same_orientation = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_largest_NN_same_orientation.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_NN_same_orientation_new_FIPs = []
+    for tt in total_all_data:
+        new_largest_NN_same_orientation_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_largest_FIP_NN_same_orientation = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_NN_same_orientation.append(tt[0])
+
+    if grain_2424_largest_NN_same_orientation != new_largest_NN_same_orientation_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # 1
+    ''' NN with most shared surface area has same orientation '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\neighbor_with_most_shared_area_has_same_orientation_as_GOI')
+    num_inst = 1
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_most_shared_area_NN_same_orientation = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_most_shared_area_NN_same_orientation.append(total_all_data[ii].transpose()[0][kk])
+
+    new_most_shared_area_NN_same_orientation_new_FIPs = []
+    for tt in total_all_data:
+        new_most_shared_area_NN_same_orientation_new_FIPs.append(tt[0][0])
+
+
+    grain_with_new_most_shared_area_FIP_NN_same_orientation = []
+    for tt in total_added_g:
+        grain_with_new_most_shared_area_FIP_NN_same_orientation.append(tt[0])
+
+    if grain_2424_most_shared_area_NN_same_orientation != new_most_shared_area_NN_same_orientation_new_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # 1
+    ''' COMPARE TO ORIGINAL FROM 250^3 '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\original_cropped_72^3_region_around_third_highest_FIP_grain')
+    num_inst = 1
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_original = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_original.append(total_all_data[ii].transpose()[0][kk])
+
+    new_original_FIPs = []
+    for tt in total_all_data:
+        new_original_FIPs.append(tt[0][0])
+
+
+    oringial_FIP_same_orientation = []
+    for tt in total_added_g:
+        oringial_FIP_same_orientation.append(tt[0])
+
+
+    if grain_2424_original != new_original_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+    # ---> All largest PSSR in grain 556 (indexed at 1). 
+    
+
+
+    ''' This website below has more information on creating informative plots! '''
+
+    # https://towardsdatascience.com/scattered-boxplots-graphing-experimental-results-with-matplotlib-seaborn-and-pandas-81f9fa8a1801
+
+    # This first data set contains all the FIPs that occur inside the grain of interest (555, indexed at 0)
+    dataset1 = [grain_2424_change_first_NN_most_shared_area, 
+                new_largest_first_NN_new_FIPs, new_largest_second_NN_new_FIPs, new_largest_third_NN_new_FIPs, new_largest_fourth_NN_new_FIPs, new_largest_fifth_NN_new_FIPs, 
+                grain_2424_change_ALL_first_NN_new_FIPs, grain_2424_change_ALL_second_NN_new_FIPs, grain_2424_change_ALL_third_NN_new_FIPs, new_largest_ALL_fourth_NN_new_FIPs, new_largest_ALL_fifth_NN_new_FIPs,
+                grain_2424_largest_NN_same_orientation, grain_2424_most_shared_area_NN_same_orientation]
+    
+    # Define names for figure
+    names1 = ['$1^{st}$ NN with most SA', 
+              'Largest $1^{st}$ NN','Largest $2^{nd}$ NN', 'Largest $3^{rd}$ NN', 'Largest $4^{th}$ NN', 'Largest $5^{th}$ NN', 
+              'All 20 $1^{st}$ NNs','All 68 $2^{nd}$ NNs', 'All 173 $3^{rd}$ NNs', 'All 353 $4^{th}$ NNs', 'All 597 $5^{th}$ NNs',
+              'Largest $1^{st}$ NN, same ori', '$1^{st}$ NN with most SA, same ori']
+              
+
+
+    vals, names, xs = [],[],[]
+
+    for i, col in enumerate(names1):
+        vals.append(dataset1[i])
+        names.append(col)
+        xs.append(np.random.normal(i + 1, 0.04, len(dataset1[i])))  # adds jitter to the data points - can be adjusted
+
+    # This SECOND data set plots FIPs that do not occur inside the grain of interest, but which are the highest in the microstructure
+    
+    dataset2 = [new_largest_ALL_first_NN_new_FIPs, new_largest_ALL_third_NN_new_FIPs[2]]
+    vals_1, xs_1 = [], []
+
+    # for kk in range(2):
+        # vals_1.append(dataset2[kk])
+        # xs_1.append(np.random.normal(2 * kk + 7, 0.04, len(dataset2[kk])))  # adds jitter to the data points - can be adjusted
+
+    # Manually add "jitter" ...    
+    vals_1.append(dataset2[0])
+    xs_1.append(np.random.normal(2 * 0 + 7, 0.04, len(dataset2[0])))  # adds jitter to the data points - can be adjusted 
+
+    vals_1.append(dataset2[1])
+    xs_1.append(np.random.normal(2 * 1 + 7, 0.04, 1))  # adds jitter to the data points - can be adjusted 
+
+    # Store FIPs pickle file!
+
+    fname = '3rd_highest_FS_FIP_variation_first_plot_data.p'
+    h1 = open(os.path.join(store_dirr, fname), 'wb')
+    p.dump([dataset1, dataset2, names1], h1)
+    h1.close()
+
+
+    fontsizee = 7
+
+    fig = plt.figure(facecolor="white", figsize=(7.5, 5), dpi=1200)
+    plt.rcParams["mathtext.default"] = "regular"
+    plt.boxplot(vals[0:11]+[1,1], labels=names, zorder = 1, showfliers=False)
+
+
+    # palette = ['g'] * 5 + ['b'] * 5 + ['m'] * 1 + ['c'] * 2
+    palette = ['m'] * 1 + ['g'] * 5 + ['b'] * 5 + ['c'] * 2
+    markers = ['D'] * 1 + ['o'] * 5 + ['^'] * 5 + ['s'] * 2
+
+    for x, val, c, m in zip(xs, vals, palette, markers):
+        plt.scatter(x, val, alpha=0.5, color = c, zorder = 2, marker = m)
+        
+    plt.plot((0,16),(new_original_FIPs,new_original_FIPs), linestyle = '--', c = 'k', linewidth=1.0, zorder = 1, label = 'Maximum FIP in unaltered microstructure')
+
+    # Star markers for largest FIP in entire 1st NN results
+    p1 = plt.scatter(xs_1[0], vals_1[0], alpha=0.65, marker = '^', color = 'r', s = 25, label = 'Largest in entire microstructure, not in GOI')
+
+    # Star markers for largest FIP in entire 1st NN results
+    p2 = plt.scatter(xs_1[1], vals_1[1], alpha=0.65, marker = '^', color = 'r', s = 25)
+
+    # l = plt.legend([(p1, p2)], ['Largest FIPs in microstructure'], numpoints=1, fontsize = 6, loc = 'upper right', handler_map={tuple: HandlerTuple(ndivide=None)})
+
+    plt.legend(framealpha = 1, loc = 'lower left', fontsize = fontsizee)
+    plt.ticklabel_format(style = 'sci', axis='y', scilimits=(0,0), useMathText = True)
+
+    plt.ylim(0.0036, 0.012)
+    plt.xlim(0.5,13.5)
+
+    plt.ylabel('Largest sub-band averaged FS FIP in grain 556')    
+    plt.xlabel('Altered grain orientations')    
+    plt.grid(True, zorder = 1, axis = 'y', alpha = 0.4)
+    plt.xticks(rotation = 30, fontsize = fontsizee)
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, '3rd_highest_FS_FIP_variation_first_plot'))
+    plt.close()
+
+def read_and_plot_secondary_FIPs():
+    
+    # This function will read in the FIPs to create the second plot for the grain that manifests the 3rd highest FIP in the 160,000 grain microstructure
+
+    # 5
+    ''' Change 5 in 3rd layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\Layer3_Largest_5_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_in_layer_3 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_in_layer_3.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_in_layer_3 = []
+    for tt in total_all_data:
+        new_largest_change_5_in_layer_3.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_in_layer_3 = []
+    for tt in total_added_g:
+            grain_with_new_largest_FIP_change_5_in_layer_3.append(tt[0])
+
+    # 5
+    ''' Change 5% in 3rd layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\Layer3_Largest_5Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_perc_in_layer_3 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_perc_in_layer_3.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_perc_in_layer_3 = []
+    for tt in total_all_data:
+        new_largest_change_5_perc_in_layer_3.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_perc_in_layer_3 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_5_perc_in_layer_3.append(tt[0])
+
+    # 5
+    ''' Change 20% in 3rd layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\Layer3_Largest_20Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_20_perc_in_layer_3 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_20_perc_in_layer_3.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_20_perc_in_layer_3 = []
+    for tt in total_all_data:
+        new_largest_change_20_perc_in_layer_3.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_20_perc_in_layer_3 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_20_perc_in_layer_3.append(tt[0])
+
+    # 5
+    ''' Change 5 in 4th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\Layer4_Largest_5_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_in_layer_4 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_in_layer_4.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_in_layer_4 = []
+    for tt in total_all_data:
+        new_largest_change_5_in_layer_4.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_in_layer_4 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_5_in_layer_4.append(tt[0])
+
+    # 5
+    ''' Change 5% in 4th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\Layer4_Largest_5Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_perc_in_layer_4 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_perc_in_layer_4.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_perc_in_layer_4 = []
+    for tt in total_all_data:
+        new_largest_change_5_perc_in_layer_4.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_perc_in_layer_4 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_5_perc_in_layer_4.append(tt[0])
+
+    # 5
+    ''' Change 20% in 4th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\Layer4_Largest_20Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_20_perc_in_layer_4 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_20_perc_in_layer_4.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_20_perc_in_layer_4 = []
+    for tt in total_all_data:
+        new_largest_change_20_perc_in_layer_4.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_20_perc_in_layer_4 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_20_perc_in_layer_4.append(tt[0])
+
+    # 5
+    ''' Change 5 in 5th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\Layer5_Largest_5_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_in_layer_5 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_in_layer_5.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_in_layer_5 = []
+    for tt in total_all_data:
+        new_largest_change_5_in_layer_5.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_in_layer_5 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_5_in_layer_5.append(tt[0])
+
+    # 5
+    ''' Change 5% in 5th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\Layer5_Largest_5Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_5_perc_in_layer_5 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_5_perc_in_layer_5.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_5_perc_in_layer_5 = []
+    for tt in total_all_data:
+        new_largest_change_5_perc_in_layer_5.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_5_perc_in_layer_5 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_5_perc_in_layer_5.append(tt[0])
+
+    # 5
+    ''' Change 20% in 5th layer '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\Layer5_Largest_20Percent_Grain')
+    num_inst = 5
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_change_20_perc_in_layer_5 = []
+
+
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        grain_2424_change_20_perc_in_layer_5.append(total_all_data[ii].transpose()[0][kk])
+
+    new_largest_change_20_perc_in_layer_5 = []
+    for tt in total_all_data:
+        new_largest_change_20_perc_in_layer_5.append(tt[0][0])
+
+    grain_with_new_largest_FIP_change_20_perc_in_layer_5 = []
+    for tt in total_added_g:
+        grain_with_new_largest_FIP_change_20_perc_in_layer_5.append(tt[0])
+
+    # --> All FIPs occur in the grain of interest (555, indexed at 0)
+
+    # 1
+    ''' COMPARE TO ORIGINAL FROM 250^3 '''
+    directory = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\data\original_cropped_72^3_region_around_third_highest_FIP_grain')
+    num_inst = 1
+
+    total_fips = []
+    total_all_data = []
+    total_added_g  = []
+
+    # NOTE: 'all_data' is indexed at 0!
+
+    for ii in range(num_inst):
+        print('On instantiation %d.' % ii)
+        new_all_fs_fips, all_data, added_g = read_FIPs_from_certain_grain(directory, ii)
+
+        total_fips.append(new_all_fs_fips)
+        total_all_data.append(all_data)
+        total_added_g.append(added_g)
+
+
+    find_2424 = []
+    for vals in total_all_data:
+    # Find grain 2424 ...
+        find_2424.append(np.where(vals.transpose()[1] == grain_num_of_interest)[0][0])
+
+
+    grain_2424_original = []
+    for ii, kk in enumerate(find_2424):
+        # print(ii,kk)
+        
+        grain_2424_original.append(total_all_data[ii].transpose()[0][kk])
+
+    new_original_FIPs = []
+    for tt in total_all_data:
+        new_original_FIPs.append(tt[0][0])
+
+
+    oringial_FIP_same_orientation = []
+    for tt in total_added_g:
+        oringial_FIP_same_orientation.append(tt[0])
+
+
+    if grain_2424_original != new_original_FIPs:
+        print('Maximum FIP(s) occurs in different grains for directory:      %s' % directory)
+
+
+
+
+
+
+
+
+
+
+
+
+    # https://towardsdatascience.com/scattered-boxplots-graphing-experimental-results-with-matplotlib-seaborn-and-pandas-81f9fa8a1801
+
+
+    dataset1 = [grain_2424_change_5_in_layer_3, grain_2424_change_5_in_layer_4, grain_2424_change_5_in_layer_5,
+                grain_2424_change_5_perc_in_layer_3, grain_2424_change_5_perc_in_layer_4, grain_2424_change_5_perc_in_layer_5,
+                grain_2424_change_20_perc_in_layer_3, grain_2424_change_20_perc_in_layer_4, grain_2424_change_20_perc_in_layer_5]
+
+    names1 = ['Largest 5 in $3^{rd}$ layer',   'Largest 5 in $4^{th}$ layer',   'Largest 5 in $5^{th}$ layer',
+              'Largest 5% in $3^{rd}$ layer',  'Largest 5% in $4^{th}$ layer',  'Largest 5% in $5^{th}$ layer',
+              'Largest 20% in $3^{rd}$ layer', 'Largest 20% in $4^{th}$ layer', 'Largest 20% in $5^{th}$ layer']
+
+
+    vals, names, xs = [],[],[]
+
+    for i, col in enumerate(names1):
+        vals.append(dataset1[i])
+        names.append(col)
+        xs.append(np.random.normal(i + 1, 0.04, len(dataset1[i])))  # adds jitter to the data points - can be adjusted
+
+
+    # dataset2 = [new_largest_ALL_first_NN_new_FIPs, new_largest_ALL_second_NN_new_FIPs]
+    # vals_1, xs_1 = [], []
+
+    # for kk in range(2):
+    #     vals_1.append(dataset2[kk])
+    #     xs_1.append(np.random.normal(kk + 7, 0.04, len(dataset2[kk])))  # adds jitter to the data points - can be adjusted
+        
+        
+    # Store FIPs pickle file!
+
+    fname = '3rd_highest_FS_FIP_variation_second_plot_data.p'
+    h1 = open(os.path.join(store_dirr, fname), 'wb')
+    p.dump([dataset1, names1], h1)
+    h1.close()
+
+
+    fontsizee = 7
+
+    fig = plt.figure(facecolor="white", figsize=(7.5, 4.5), dpi=1200)
+    plt.rcParams["mathtext.default"] = "regular"
+    plt.boxplot(vals[0:9], labels=names, zorder = 1, showfliers=False)
+
+
+    # palette = ['g'] * 5 + ['b'] * 5 + ['m'] * 1 + ['c'] * 2
+    # palette = ['m'] * 1 + ['g'] * 5 + ['b'] * 5 + ['c'] * 2
+    markers = ['p'] * 3 + ['d'] * 3 + ['*'] * 3
+    palette = ['darkmagenta', 'crimson', 'deepskyblue', 'darkmagenta', 'crimson', 'deepskyblue', 'darkmagenta', 'crimson', 'deepskyblue']
+    palette = ['m', 'r', 'b', 'm', 'r', 'b', 'm', 'r', 'b']
+
+    for x, val, c, m in zip(xs, vals, palette, markers):
+        plt.scatter(x, val, alpha=0.55, color = c, zorder = 2, marker = m)
+        
+    plt.plot((0,16),(new_original_FIPs,new_original_FIPs), linestyle = '--', c = 'k', linewidth=1.0, zorder = 1, label = 'Maximum FIP in unaltered $72^{3}$ microstructure')
+
+    # Star markers for largest FIP in entire 1st NN results
+    # p1 = plt.scatter(xs_1[0], vals_1[0], alpha=0.65, marker = '^', color = 'r', s = 25, label = 'Largest in entire microstructure, not in GOI')
+
+    # Star markers for largest FIP in entire 1st NN results
+    # p2 = plt.scatter(xs_1[1], vals_1[1], alpha=0.65, marker = '^', color = 'r', s = 25)
+
+    # l = plt.legend([(p1, p2)], ['Largest FIPs in microstructure'], numpoints=1, fontsize = 6, loc = 'upper right', handler_map={tuple: HandlerTuple(ndivide=None)})
+
+    plt.legend(framealpha = 1, loc = 'lower left', fontsize = fontsizee)
+
+    plt.yticks(np.arange(0.97e-2, 1.17e-2, 0.3e-3))
+
+    plt.ticklabel_format(style = 'sci', axis='y', scilimits=(0,0), useMathText = True)
+
+    # plt.ylim(0.0036, 0.014)
+    plt.ylim(0.97e-2, 1.17e-2)
+    plt.xlim(0.5,9.5)
+
+    plt.ylabel('Largest sub-band averaged FS FIP in grain 556')    
+    plt.xlabel('Altered grain orientations')    
+    plt.grid(True, zorder = 1, axis = 'y', alpha = 0.4)
+    plt.xticks(rotation = 30, fontsize = fontsizee)
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, '3rd_highest_FS_FIP_variation_second_plot'))
+    plt.close()
+
+
+
+
+
+
+
+
+def main():
+    read_and_plot_main_FIPs()
+    read_and_plot_secondary_FIPs()
+
+if __name__ == "__main__":
+    main()

--- a/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_FIP_correlations.py
+++ b/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_FIP_correlations.py
@@ -1,0 +1,1470 @@
+import numpy as np
+import os
+import matplotlib.pyplot as plt
+import re
+import pickle as p
+import linecache
+import operator
+from itertools import combinations
+import time
+import shutil
+import fileinput
+import subprocess
+import pandas as pd
+import time
+from mpl_toolkits.mplot3d import Axes3D
+import math
+import xlrd
+
+# Get name of directory that contains the PRISMS-Fatigue scripts
+DIR_LOC = os.path.dirname(os.path.abspath(__file__))
+
+# Define FCC octahedral slip plane normal directions
+FCC_OCT_NORMALS = np.asarray([[1,1,1],
+[-1,1,1],
+[1,1,-1],
+[1,-1,1]]) / (3**0.5)
+
+# Define FCC octahedral slip directions
+FCC_OCT_SLIP_DIRS = np.asarray([[0,1,-1],
+[-1,0,1],
+[1,-1,0],
+[0,-1,1],
+
+[-1,0,-1],
+[1,1,0],
+[0,-1,-1],
+[1,0,1],
+
+[-1,1,0],
+[0,1,1],
+[1,0,-1],
+[-1,-1,0]]) / (2**0.5)
+
+
+# Combine slip planes and slip directions for FCC and verify normality
+FCC_SLIP_SYSTEMS = np.zeros((12,2,3))
+for tt in range(12):
+    FCC_SLIP_SYSTEMS[tt][0] = FCC_OCT_NORMALS[int(tt/3)]
+    FCC_SLIP_SYSTEMS[tt][1] = FCC_OCT_SLIP_DIRS[tt]
+    # print(np.dot(FCC_SLIP_SYSTEMS[tt][0],FCC_SLIP_SYSTEMS[tt][1]))
+
+def read_data_from_160000_microstructure(directory):
+    # Additional unused function to read in the largest sub-band averaged FIPs (one per grain) from a single microstructure instantiation
+    # This is particularly useful when considering a very large SVE with more than ~10,000 grains as this function can take a long time!
+    
+    print('Read FIP data from the 160,000 grain microstructure')
+
+    # Specify name of pickle file with sub-band averaged FIPs
+    fname = os.path.join(directory, 'sub_band_averaged_FS_FIP_pickle_0.p')
+    
+    # Read in FIPs
+    h1 = open(fname,'rb')
+    fips = p.load(h1)
+    h1.close()
+    
+    # Sort in descending order
+    sorted_fips = sorted(fips.items(), key=operator.itemgetter(1))
+    sorted_fips.reverse()    
+    
+    # Initialize list of just FIPs
+    new_all_fs_fips = []
+
+    # Initialize list to keep track of which grains have already been considered
+    added_g = []
+    
+    # Initialize array with more detailed FIP data
+    # FIP, grain number, slip system number, layer number, sub-band region number
+    all_data = np.zeros(((len(sorted_fips)),5))
+    
+    for kk in range(len(sorted_fips)):
+        new_all_fs_fips.append(sorted_fips[kk][1])
+        
+        all_data[kk][0] = sorted_fips[kk][1]
+        all_data[kk][1] = sorted_fips[kk][0][0]
+        all_data[kk][2] = sorted_fips[kk][0][1]
+        all_data[kk][3] = sorted_fips[kk][0][2]
+        all_data[kk][4] = sorted_fips[kk][0][3]  
+    
+        added_g.append(sorted_fips[kk][0][0])
+    
+    # Store all data
+    fname = 'all_FIP_data_compiled.p'    
+    h1 = open(os.path.join(directory, fname),'wb')
+    p.dump([new_all_fs_fips, all_data, added_g],h1)
+    h1.close()
+    
+    return new_all_fs_fips, all_data, added_g
+
+def read_elements_of_highest_FIPs(directory, all_data, num_extract):
+
+    # WARNING: This function is extremely memory intensive because of the very large size of the file 'sub_band_info_0.p' !!! 
+    # This function reads in which elements belong to the sub bands that manifest the largest FIPs
+    
+    fname3 = os.path.join(directory, 'top_elem_fips.p')
+    
+    if not os.path.exists(fname3):
+
+        # Read file that contains sub band element data
+        fname = os.path.join(directory, 'sub_band_info_0.p')
+        h1 = open(fname,'rb')
+        master_sub_band_dictionary,number_of_layers,number_of_sub_bands = p.load(h1, encoding = 'latin1')
+        h1.close()
+        
+        elems = []
+        
+        for kk in range(num_extract):
+        
+            # The values read in are indexed at 0!
+            grain_temp    = all_data[kk][1]
+            SS_temp       = int(all_data[kk][2]/3)
+            layer_temp    = all_data[kk][3]
+            sub_band_temp = all_data[kk][4]
+
+            elems.append(master_sub_band_dictionary[grain_temp,SS_temp,layer_temp,sub_band_temp])
+            
+        h3 = open(fname3, 'wb')
+        p.dump(elems,h3)
+        h3.close()
+        
+    else:
+        h3 = open(fname3, 'rb')
+        elems = p.load(h3)
+        h3.close()
+    
+    return elems
+
+def read_FIP_components(directory):
+
+    # Read components of the highest FIPs
+    
+    fname4 = os.path.join(directory, 'PRISMS_FIP_components_FS_FIP_0.p')
+    h4 = open(fname4,'rb')
+    plastic_shear_strain_range_FIP, normal_stresses_FIP = p.load(h4)
+    h4.close()
+    
+    return plastic_shear_strain_range_FIP, normal_stresses_FIP
+
+def flatten(d):
+    return {i for b in [[i] if not isinstance(i, list) else flatten(i) for i in d] for i in b}
+    
+def EulerToMat(theta):
+    # Calculates Rotation Matrix given euler angles.
+    R = np.zeros((3,3))
+    
+    s1 = math.sin(theta[0])
+    c1 = math.cos(theta[0])
+    s2 = math.sin(theta[1])
+    c2 = math.cos(theta[1])
+    s3 = math.sin(theta[2])
+    c3 = math.cos(theta[2])
+    
+    R[0,0] = c1*c3-s1*s3*c2
+    R[1,0] = s1*c3+c1*s3*c2
+    R[2,0] = s3*s2
+    R[0,1] = -c1*s3-s1*c3*c2
+    R[1,1] = -s1*s3+c1*c3*c2
+    R[2,1] = c3*s2
+    R[0,2] = s1*s2
+    R[1,2] = -c1*s2
+    R[2,2] = c2    
+ 
+    return R    
+
+def rotate_tensor(theta,tensor):
+    # Rotates a tensor by Euler angles
+    
+    R   = EulerToMat(theta)
+    R_t = np.transpose(R)
+    
+    tensor_rotated = np.matmul(R_t,np.matmul(tensor,R))
+    return tensor_rotated
+    
+def rotate_vector(theta,vector):
+    # Rotates a vector by Euler angles
+    
+    R   = EulerToMat(theta)
+    R_t = np.transpose(R)
+    
+    tensor_rotated = np.matmul(vector,R_t)
+    # tensor_rotated = np.matmul(R_t,vector)
+    return tensor_rotated   
+
+def calculate_FCC_Schmid_Factors(orientations, grains, load_dir):
+
+    # Initialize array for calculated Schmid Factors
+    SF_temp = np.ones((len(orientations),12))
+    
+    # Iterate through grains of interest
+    for gg in grains:
+    
+        SF_temp[gg,:] = calculate_FCC_SF(orientations[gg],load_dir)
+
+    return SF_temp[grains]
+    
+def calculate_FCC_SF(orientations,load_dir):
+
+    # Rotate directions
+    rotated_vec = rotate_vector(orientations,FCC_SLIP_SYSTEMS) 
+    
+    # Initialize array for calculated Schmid Factors
+    temp_calc = np.zeros((12))
+    
+    # Iterate and calculate for each slip system
+    for tt in range(12):
+    
+        temp_calc[tt] = np.abs( np.dot(rotated_vec[tt][0],load_dir) * np.dot(rotated_vec[tt][1],load_dir) ) 
+    
+    return temp_calc   
+
+def top_50_FIPs_vtk():
+
+    # Append a new scalar to the .vtk file to indicate grains that contain the highest 50 FIPs
+    print('Appending top 50 FIP grains to .vtk file for visualization')
+    directory = os.path.join(DIR_LOC, r'Section_4\160000_x_1')
+    
+    fips, all_data, added_g = read_data_from_160000_microstructure(directory)
+    
+    Fname_vtk_loc = os.path.join(directory, 'Output_FakeMatl_0_FIPs.vtk')
+    Fname_vtk_new = os.path.join(directory, 'Output_FakeMatl_0_top_50_FIP_grains.vtk')
+    
+    # Create copy of original .vtk file in case something goes wrong!
+    shutil.copy(Fname_vtk_loc, Fname_vtk_new)
+
+    vtk_first_part = []
+    with open(Fname_vtk_loc) as f:
+        for line in f.readlines():
+            vtk_first_part.append(line)
+            if 'EulerAngles' in line:
+                vtk_first_part.append('LOOKUP_TABLE default \n')
+                break
+    f.close()
+
+    # Get just lines with grain IDs
+    # NOTE: THESE NUMBERS BELOW WILL CHANGE BASED ON THE FIRST LINES IN THE .VTK FILE!!
+    # FOR THE 160,000 GRAIN MICROSTRUCTURE, WE MUST OMIT THE FIRST 51 LINES, AS SHOWN BELOW
+    grain_IDs = vtk_first_part[51:-2]
+
+    ''' read in "highest_fips_and_grains.p" in the 160^3 results folder '''
+    top_50_grains = all_data.transpose()[1].astype(int)[0:50]
+    top_50 = [ii + 1 for ii in top_50_grains]
+
+    f_vtk = open(Fname_vtk_new,'a')
+
+    f_vtk.write('SCALARS Top_50_FIP_grains int 1\n')
+    f_vtk.write('LOOKUP_TABLE default\n')
+
+    counter = 0
+    # Iterate through lines of grain IDs from .vtk file
+    for kk in grain_IDs:
+
+        # Get grain IDs
+        temp_grain_IDs = [int(s) for s in kk.split() if s.isdigit()]
+        
+        # Iterate through each grain ID
+        for jj in temp_grain_IDs:
+
+            if jj in top_50:
+                f_vtk.write(' 1')
+            else:
+                f_vtk.write(' 0')
+            counter += 1 
+            
+            # Write new line
+            if counter == 20:
+                f_vtk.write('\n')
+                counter = 0
+
+    f_vtk.close()
+
+def compute_correlations():
+
+    # Define directory with the 160,000 grain microstructure discretized by 250^3 elements
+    directory = os.path.join(DIR_LOC, r'Section_4\160000_x_1')
+    
+    # Define where to store plots
+    store_dirr = os.path.join(DIR_LOC, r'plots')
+    
+    # Read in orientations based on DREAM.3D generated .csv file
+    # The .csv file was edited to only contain the first set of data (i.e., data for each grain in row format)
+    df1 = pd.read_csv(os.path.join(directory, 'FeatureData_FakeMatl_0_first_chunk.csv'), index_col = False)
+    
+    # Read in various properties of grains from microstructure
+    orientations = df1[['EulerAngles_0','EulerAngles_1','EulerAngles_2']].to_numpy(dtype=float)
+    diameters = df1[['EquivalentDiameters']].to_numpy(dtype=float)
+    volumes = df1[['Volumes']].to_numpy(dtype=float)
+    centroids = df1[['Centroids_0','Centroids_1','Centroids_2']].to_numpy(dtype=float)
+
+    # Compile data from the 160,000 grain microstructure
+    fips, all_data, added_g = read_data_from_160000_microstructure(directory)
+
+    # Calculate Schmid Factors for grains in the 160,000 grain microstructure
+    SFs = calculate_FCC_Schmid_Factors(orientations, added_g, [1,0,0])
+
+    # Focus on the highset 250 FIPs
+    num_fips_focus = 250
+    SFs_250 = SFs[:num_fips_focus]
+
+    # Determine the Schmid Factor of the slip system that manifests the highest FIP in each grain
+    SF_of_highest_FIPs = np.zeros((num_fips_focus))
+    
+    for ii, vv in enumerate(all_data.transpose()[2][:num_fips_focus]):
+        SF_of_highest_FIPs[ii] = SFs_250[ii][int(vv)]
+    
+    
+    ''' Plot figures '''
+    
+    # Specify how many of the highest FIPs should be investigated
+    top_fips_to_plot = 50
+    
+    # Plot Schmid Factors of the highest grains
+    print('Plotting Schmid Factors')
+    fig = plt.figure(facecolor="white", figsize=(6, 4), dpi=1200)
+    cm = plt.cm.get_cmap('jet')
+    plt.scatter(range(top_fips_to_plot), SF_of_highest_FIPs[0:top_fips_to_plot], c = all_data.transpose()[0][0:top_fips_to_plot], cmap=cm, zorder = 2)
+    plt.grid(zorder = 1)
+    cbarr = plt.colorbar()
+    cbarr.set_label("Sub-band averaged FIP")
+
+    plt.xlabel('Grain ID by FIP rank')
+    plt.ylabel('Schmid Factor of Slip System with largest FIP')
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, 'Schmid_Factor_by_grain_ID_FIP_rank_top_%d_FIPs' % top_fips_to_plot))
+    plt.close()
+
+
+    # Specify how many of the highest FIPs should be investigated
+    top_fips_to_plot = 50
+
+    # Plot grain diameters of the highest grains
+    dia_highest_FIP_grains = np.zeros((num_fips_focus))
+    
+    for ii, vv in enumerate(all_data.transpose()[1][:num_fips_focus]):
+        dia_highest_FIP_grains[ii] = diameters[int(vv)][0]
+    
+    print('Plotting grain diameters')
+    # Plot the grain diameters of the grains that manifest the highest 50 FIPs
+    fig = plt.figure(facecolor="white", figsize=(6, 4), dpi=1200)
+    cm = plt.cm.get_cmap('jet')
+    plt.scatter(range(top_fips_to_plot), dia_highest_FIP_grains[0:top_fips_to_plot], c = all_data.transpose()[0][0:top_fips_to_plot], cmap=cm, zorder = 2)
+    plt.grid(zorder = 1)
+    cbarr = plt.colorbar()
+    cbarr.set_label("Sub-band averaged FIP")
+
+    plt.xlabel('Grain ID by FIP rank')
+    plt.ylabel('Equivalent grain diameter')
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, 'Grain_diameter_by_grain_ID_FIP_rank_top_%d_FIPs' % top_fips_to_plot))
+    plt.close()
+
+
+
+    ''' Unused functions, left for prospective users '''
+    # fig = plt.figure(facecolor="white", figsize=(7.5, 5), dpi=1200)
+    # plt.scatter(SF_of_highest_FIPs[0:top_fips_to_plot], all_data.transpose()[0][0:top_fips_to_plot], zorder = 2)
+    # plt.grid(zorder = 1)
+    # plt.xlabel('Schmid Factor of Slip System with largest FIP')
+    # plt.ylabel('FIP')
+    # plt.tight_layout()
+    # plt.savefig(os.path.join(store_dirr, 'FIPs_vs_Schmid_factor.png'))
+    # plt.close()
+    
+
+    # fig = plt.figure(facecolor="white", figsize=(7.5, 5), dpi=1200)
+    # cm = plt.cm.get_cmap('jet')
+    # plt.scatter(SF_of_highest_FIPs[0:top_fips_to_plot], all_data.transpose()[0][0:top_fips_to_plot], zorder = 2, c = all_data.transpose()[0][0:top_fips_to_plot], cmap=cm)
+    # plt.grid(zorder = 1)
+    # plt.colorbar()
+    # plt.xlabel('Schmid Factor of Slip System with largest FIP')
+    # plt.ylabel('FIP')
+    # plt.tight_layout()
+    # plt.savefig(os.path.join(store_dirr, 'FIPs_vs_Schmid_factor_with_colored_FIPs.png'))
+    # plt.close()
+    
+    
+    
+    # Read in the two components of the highset FIP to compute correlations
+    plastic_shear_strain_range_FIP, normal_stresses_FIP = read_FIP_components(directory)
+
+    # Read in the elements of the highest FIPs (not ALL FIPs to reduce memory demands)
+    elems = read_elements_of_highest_FIPs(directory, all_data, num_fips_focus)
+   
+
+    # Calculate the plastic shear strain range and normal stresses over the same sub bands that manifest the highest FIPs in the 160,000 grain microstructure
+    num_fips = 50
+ 
+    FIP_plastic_range = np.zeros((num_fips))
+    raw_normal_stress = np.zeros((num_fips))
+    FIP_normal_stress = np.zeros((num_fips))
+    FIP_recalculated  = np.zeros((num_fips))
+    FIP_perc_diff     = np.zeros((num_fips))
+    
+    for ii in range(num_fips):
+        
+        FIP_plastic_range[ii] = np.mean(plastic_shear_strain_range_FIP[[ppp - 1 for ppp in elems[ii]]], axis = 0)[int(all_data[ii][2])]
+        raw_normal_stress[ii] = np.mean( normal_stresses_FIP[[ppp - 1 for ppp in elems[ii]]], axis = 0)[int(all_data[ii][2])]
+        FIP_normal_stress[ii] = np.mean((1 + 10 * (normal_stresses_FIP[[ppp - 1 for ppp in elems[ii]]] / 517)), axis = 0)[int(all_data[ii][2])]
+        FIP_recalculated[ii]  = FIP_plastic_range[ii] * FIP_normal_stress[ii]
+        FIP_perc_diff[ii]     = 100 * (FIP_recalculated[ii] - all_data[ii][0]) / all_data[ii][0]
+    
+    
+    # Plot the plastic shear strain range of the sub bands that manifest the highest 50 FIPs
+    print('Plotting plastic shear strain range')
+    fig = plt.figure(facecolor="white", figsize=(6, 4), dpi=1200)
+    cm = plt.cm.get_cmap('jet')
+    plt.scatter(range(num_fips), FIP_plastic_range, c = all_data.transpose()[0][:num_fips], cmap=cm, zorder = 2)
+    plt.grid(zorder = 1)
+    plt.colorbar()
+
+    plt.ylim(0.0011, 0.0021)
+    plt.xlabel('Grain ID by FIP rank')
+    plt.ylabel('PSSR on slip system with largest FIP')
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, 'PSSR_by_grain_ID_FIP_rank_top_%d_FIPs' % num_fips))
+    plt.close()   
+    
+    print('Plotting normal stresses')
+    # Plot the normal stress of the sub bands that manifest the highest 50 FIPs
+    fig = plt.figure(facecolor="white", figsize=(6, 4), dpi=1200)
+    cm = plt.cm.get_cmap('jet')
+    plt.scatter(range(num_fips), raw_normal_stress, c = all_data.transpose()[0][:num_fips], cmap=cm, zorder = 2)
+    plt.grid(zorder = 1)
+    plt.colorbar()
+    
+    plt.ylim(200, 310)
+    plt.xlabel('Grain ID by FIP rank')
+    plt.ylabel('Stress normal to slip system with largest FIP')
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, 'Normal_stress_by_grain_ID_FIP_rank_top_%d_FIPs' % num_fips))
+    plt.close()   
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+    
+
+    ''' Read in list of neighbors '''
+
+    # https://stackoverflow.com/questions/61885456/how-to-read-each-row-of-excel-file-into-a-list-so-as-to-make-whole-data-a-list-o
+    listoflist = []
+    workbook1 = xlrd.open_workbook(os.path.join(directory, r'FeatureData_FakeMatl_0_neighbor_list.xlsx'))
+    b = workbook1.sheet_by_index(0)
+    for i in range(0,b.nrows):
+        rli = []
+        for j in range(0,b.ncols):
+            if b.cell_value(i,j) != '':
+                rli.append(b.cell_value(i,j))
+        listoflist.append(rli)
+    
+    neighbor_list = []   
+    for kk in listoflist:
+        neighbor_list.append([int(pp) for pp in kk[2:]])
+        
+        
+    ''' Read in list of shared surface area! '''        
+    
+    listoflist = []
+    workbook1 = xlrd.open_workbook(os.path.join(directory, r'FeatureData_FakeMatl_0_shared_surface_area_list.xlsx'))
+    b = workbook1.sheet_by_index(0)
+    for i in range(0,b.nrows):
+        rli = []
+        for j in range(0,b.ncols):
+            if b.cell_value(i,j) != '':
+                rli.append(b.cell_value(i,j))
+        listoflist.append(rli)
+    
+    shared_surface_area_list = []   
+    for kk in listoflist:
+        shared_surface_area_list.append([pp for pp in kk[2:]])    
+    
+    
+    # Let's examine the grains around the grain with the largest FIP
+    largest_FIP_grain = int(all_data[0][1])
+    nearest_neighbor_grains = [rr - 1 for rr in neighbor_list[largest_FIP_grain]]
+    
+    All_grain_SFs = calculate_FCC_Schmid_Factors(orientations, [x for x in range(len(orientations))], [1,0,0])
+    
+    
+    ''' Unused functions, left for prospective users '''   
+    # # CRUCIAL: GRAINS ARE ALSO ORIGINALLY INDEXED AT 1 !!!
+    
+    # SFs_of_grains_neighboring_largest_FIP_grain = calculate_FCC_Schmid_Factors(orientations, nearest_neighbor_grains, [1,0,0])
+    
+    # # Get largest Schmid Factor in the grains neighboring the largest FIP Grain
+    
+    # np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+    # np.mean(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+    
+
+    # num_neigh_highest_FIP = len(SFs_of_grains_neighboring_largest_FIP_grain)
+    
+    # # Same plot but different axes
+    # fig, ax1 = plt.subplots()
+    # ax1.plot(range(num_neigh_highest_FIP), shared_surface_area_list[84852], c = 'g', linestyle = ':', label = 'Shared surface area')
+    # ax2 = ax1.twinx()
+    # ax2.plot(range(num_neigh_highest_FIP), np.mean(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1), c = 'r', label = 'Mean SF')
+    # ax2.plot(range(num_neigh_highest_FIP), np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1), c = 'm', label = 'Max SF')     
+    # fig.legend()
+    # fig.tight_layout()
+    # plt.show()
+    # plt.close()
+    
+    
+    
+    # # "Lowest" possible SFs when pulling along the [111] direction
+    # calculate_FCC_Schmid_Factors(np.zeros((2,3)),[0],[1,1,1]/np.sqrt(3))
+    
+    # # Calculate SF when straining along [111] plane
+    
+    # ori_1 = np.zeros((2,3))
+    # ori_1[0] = np.asarray([0.97852153, 2.7551234 , 4.0642705 ])
+    # # ori_1[0][0] = 45 * np.pi / 180
+    
+    # calculate_FCC_Schmid_Factors(ori_1,[0],[1,0,0])
+    
+    # # Plot averages as histogram
+    
+    # plt.hist(np.mean(All_grain_SFs, axis = 1), bins = 1000)
+    # plt.show()
+    # plt.close()
+    
+    
+    # plt.hist(np.max(All_grain_SFs, axis = 1), bins = 1000)
+    # plt.show()
+    # plt.close()   
+
+
+
+
+
+
+
+
+
+
+    ''' Misorientation analysis! '''
+    
+    # Read in misorientations calculated by DREAM.3D
+    
+    listoflist = []
+    workbook1 = xlrd.open_workbook(os.path.join(directory, r'miso_list_rerun.xlsx'))
+    b = workbook1.sheet_by_index(0)
+    for i in range(0,b.nrows):
+        rli = []
+        for j in range(0,b.ncols):
+            if b.cell_value(i,j) != '':
+                rli.append(b.cell_value(i,j))
+        listoflist.append(rli)
+    
+    miso_list = []   
+    for kk in listoflist:
+        miso_list.append([pp for pp in kk[2:]])    
+
+    # Verify number of neighbors for each grain
+    
+    countt = 0
+    for ii in range(len(miso_list)):
+        if len(miso_list[0]) != len(shared_surface_area_list[0]):
+            countt += 1 
+            # IT IS VERIFIED
+
+
+    ''' This section will plot all grain misorientations '''
+    flat_miso_list = [item for sublist in miso_list for item in sublist]
+    # plt.hist(flat_miso_list, bins = 1000)
+    # plt.show()
+    # plt.close()
+    
+    
+    # The average of the minimum misorientation between each grain and its neighbors:
+    avg_min_miso = np.zeros((len(miso_list)))
+    for ii, miso_act in enumerate(miso_list):
+        avg_min_miso[ii] = np.min(miso_act)
+    # np.mean(avg_min_miso)
+
+    
+    miso_of_highest_grains = []
+    avg_min_miso_of_highest_grains = np.zeros((num_fips))
+    for ii in range(num_fips):
+        miso_of_highest_grains.append(miso_list[int(all_data[ii][1])])
+    
+    for ii, miso_act in enumerate(miso_of_highest_grains):
+        avg_min_miso_of_highest_grains[ii] = np.min(miso_act)
+    # np.mean(avg_min_miso_of_highest_grains)
+
+
+
+    # FIG A; plot misorientations
+    print('Plotting correlations')
+    fig = plt.figure(facecolor="white", figsize=(6, 4), dpi=1200)
+    num_to_plot = 50
+    plt.plot(range(1, num_to_plot+1), avg_min_miso_of_highest_grains[0:num_to_plot], c = 'b', zorder = 2, label = 'Highest %d FIP grains' % num_to_plot, marker = 'o', markersize = '4')
+    plt.plot(range(1, num_to_plot+1), avg_min_miso[0:num_to_plot],  linestyle = ':', c = 'r', zorder = 2, label = 'First %d grains' % num_to_plot, marker = 's', markersize = '4')
+    plt.grid(zorder = 1)
+    plt.legend(framealpha = 1, fontsize = '9', loc = 'best')
+
+    plt.rcParams["font.family"] = "DejaVu Sans"
+    plt.rcParams["mathtext.default"] = "regular"
+
+    plt.xlabel('Grain ID by FIP rank')
+    plt.ylabel('Lowest misorientation between $1^{st}$ NN [degrees]', fontsize = '9')
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, 'Misorientations_by_grain_ID_FIP_rank_top_%d_FIPs' % num_fips))
+    plt.close()  
+
+
+
+    # FIG B; plot Schmid Factor correlation factor R1
+
+    num_to_consider = 50
+    
+    average_of_max_neighborhood_SFs = np.zeros((num_to_consider))
+    average_of_max_SF_of_all_grains = np.zeros((num_to_consider))
+    
+    # average_of_max_SF_of_all_grains = np.max(All_grain_SFs[0:num_to_consider], axis = 1)
+    
+    for ppp in range(num_to_consider):
+    
+        ''' Do for the highest FIPs first '''
+        # Let's examine the grains around the grain with the largest FIP
+        largest_FIP_grain = int(all_data[ppp][1])
+        nearest_neighbor_grains = [rr - 1 for rr in neighbor_list[largest_FIP_grain]]
+
+        # CRUCIAL: GRAINS ARE ALSO ORIGINALLY INDEXED AT 1 !!!
+        
+        SFs_of_grains_neighboring_largest_FIP_grain = calculate_FCC_Schmid_Factors(orientations, nearest_neighbor_grains, [1,0,0])
+    
+        # Get largest Schmid Factor in the grains neighboring the largest FIP Grain
+        # np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+        # np.mean(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+    
+        num_neigh_highest_FIP = len(SFs_of_grains_neighboring_largest_FIP_grain)
+        
+        average_of_max_neighborhood_SFs[ppp] = np.mean(np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1))
+        
+        # average_of_max_neighborhood_SFs[ppp] = np.mean(SFs_of_grains_neighboring_largest_FIP_grain)
+        
+        
+        
+        ''' Now repeat for the first num_to_consider grains! '''
+        
+        nearest_neighbor_grains_first = [rr - 1 for rr in neighbor_list[ppp]]
+        SFs_of_first_grains = calculate_FCC_Schmid_Factors(orientations, nearest_neighbor_grains_first, [1,0,0])
+        # np.max(SFs_of_first_grains, axis = 1)
+        num_neigh_highest_FIP = len(SFs_of_first_grains)
+    
+        average_of_max_SF_of_all_grains[ppp] = np.mean(np.max(SFs_of_first_grains, axis = 1))        
+        
+        # average_of_max_SF_of_all_grains[ppp] = np.mean(SFs_of_first_grains)
+        
+        
+    fig = plt.figure(facecolor="white", figsize=(6, 4), dpi=1200)     
+    plt.plot(range(1, num_to_plot+1), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b',  label = 'Highest %d FIP grains' % num_to_plot, zorder = 2, marker = 'o', markersize = '4') 
+    plt.plot(range(1, num_to_plot+1), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r', label = 'First %d grains' % num_to_plot, zorder = 2, marker = 's', markersize = '4', linestyle = ':') 
+    
+    # plt.scatter(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b',  label = '%d highest FIPs' % num_to_consider, zorder = 1, s = 2) 
+    # plt.scatter(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r',  label = '%d first grains' % num_to_consider, zorder = 1, s = 2)   
+    
+    plt.legend(framealpha = 1, fontsize = '9', loc = 'best')
+    plt.grid('True', zorder = 1)
+    # plt.ylim(0.9,1.25)
+    
+    plt.xlabel('Grain ID by FIP rank')
+    plt.ylabel('Largest SF in grain / average of max $1^{st}$ NN SFs')
+    
+    # plt.show()
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, 'Ratio_R1_by_grain_ID_FIP_rank_top_%d_FIPs' % num_to_consider))
+    plt.close()           
+
+
+
+    # FIG C; plot Schmid Factor correlation factor R2
+
+    num_to_consider = 50
+    
+    average_of_max_neighborhood_SFs = np.zeros((num_to_consider))
+    average_of_max_SF_of_all_grains = np.zeros((num_to_consider))
+    
+    # average_of_max_SF_of_all_grains = np.max(All_grain_SFs[0:num_to_consider], axis = 1)
+    
+    for ppp in range(num_to_consider):
+    
+        ''' Do for the highest FIPs first '''
+        # Let's examine the grains around the grain with the largest FIP
+        largest_FIP_grain = int(all_data[ppp][1])
+        nearest_neighbor_grains = [rr - 1 for rr in neighbor_list[largest_FIP_grain]]
+
+        # CRUCIAL: GRAINS ARE ALSO ORIGINALLY INDEXED AT 1 !!!
+        
+        SFs_of_grains_neighboring_largest_FIP_grain = calculate_FCC_Schmid_Factors(orientations, nearest_neighbor_grains, [1,0,0])
+    
+        # Get largest Schmid Factor in the grains neighboring the largest FIP Grain
+        # np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+        # np.mean(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+    
+        num_neigh_highest_FIP = len(SFs_of_grains_neighboring_largest_FIP_grain)
+        
+        # average_of_max_neighborhood_SFs[ppp] = np.mean(np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1))
+        
+        average_of_max_neighborhood_SFs[ppp] = np.mean(SFs_of_grains_neighboring_largest_FIP_grain)
+        
+        
+        
+        ''' Now repeat for the first num_to_consider grains! '''
+        
+        nearest_neighbor_grains_first = [rr - 1 for rr in neighbor_list[ppp]]
+        SFs_of_first_grains = calculate_FCC_Schmid_Factors(orientations, nearest_neighbor_grains_first, [1,0,0])
+        # np.max(SFs_of_first_grains, axis = 1)
+        num_neigh_highest_FIP = len(SFs_of_first_grains)
+    
+        # average_of_max_SF_of_all_grains[ppp] = np.mean(np.max(SFs_of_first_grains, axis = 1))        
+        
+        average_of_max_SF_of_all_grains[ppp] = np.mean(SFs_of_first_grains)
+        
+        
+    fig = plt.figure(facecolor="white", figsize=(6, 4), dpi=1200)     
+    plt.plot(range(1, num_to_plot+1), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b',  label = 'Highest %d FIP grains' % num_to_plot, zorder = 2, marker = 'o', markersize = '4') 
+    plt.plot(range(1, num_to_plot+1), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r', label = 'First %d grains' % num_to_plot, zorder = 2, marker = 's', markersize = '4', linestyle = ':') 
+    
+    # plt.scatter(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b',  label = '%d highest FIPs' % num_to_consider, zorder = 1, s = 2) 
+    # plt.scatter(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r',  label = '%d first grains' % num_to_consider, zorder = 1, s = 2)   
+    
+    plt.legend(framealpha = 1, fontsize = '9', loc = 'best')
+    plt.grid('True', zorder = 1)
+    plt.ylim(1.4, 2.7)
+    
+    plt.xlabel('Grain ID by FIP rank')
+    plt.ylabel('Largest SF in grain / average of $1^{st}$ NN SFs')
+    
+    # plt.show()
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, 'Ratio_R2_by_grain_ID_FIP_rank_top_%d_FIPs' % num_to_consider))
+    plt.close()       
+
+
+
+    # FIG D; plot Schmid Factor correlation factor R3
+
+    num_to_consider = 50
+    
+    average_of_max_neighborhood_SFs = np.zeros((num_to_consider))
+    average_of_max_SF_of_all_grains = np.zeros((num_to_consider))
+    
+    # average_of_max_SF_of_all_grains = np.max(All_grain_SFs[0:num_to_consider], axis = 1)
+    
+    for ppp in range(num_to_consider):
+    
+        ''' Do for the highest FIPs first '''
+        # Let's examine the grains around the grain with the largest FIP
+        largest_FIP_grain = int(all_data[ppp][1])
+        nearest_neighbor_grains = [rr - 1 for rr in neighbor_list[largest_FIP_grain]]
+        
+        second_nearest_neighbor_grains = []
+        
+        for neighbors_1 in nearest_neighbor_grains:
+            second_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+
+        flat_2nd_neighbors = list(flatten(second_nearest_neighbor_grains))
+       
+
+         
+        # CRUCIAL: GRAINS ARE ALSO ORIGINALLY INDEXED AT 1 !!!
+        
+        SFs_of_grains_neighboring_largest_FIP_grain = calculate_FCC_Schmid_Factors(orientations, flat_2nd_neighbors, [1,0,0])
+    
+        # Get largest Schmid Factor in the grains neighboring the largest FIP Grain
+        # np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+        # np.mean(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+    
+        num_neigh_highest_FIP = len(SFs_of_grains_neighboring_largest_FIP_grain)
+        
+
+        average_of_max_neighborhood_SFs[ppp] = np.mean(SFs_of_grains_neighboring_largest_FIP_grain)
+        
+        # print(num_neigh_highest_FIP)
+        ''' Now repeat for the first 100 grains! '''
+        
+        nearest_neighbor_grains_first = [rr - 1 for rr in neighbor_list[ppp]]
+        
+        
+        second_nearest_neighbor_grains_first_X_grains = []
+        
+        for neighbors_1 in nearest_neighbor_grains_first:
+            second_nearest_neighbor_grains_first_X_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+
+        flat_2nd_neighbors_first_x_Grains = list(flatten(second_nearest_neighbor_grains_first_X_grains))            
+
+        
+        SFs_of_first_grains = calculate_FCC_Schmid_Factors(orientations, flat_2nd_neighbors_first_x_Grains, [1,0,0])
+        # np.max(SFs_of_first_grains, axis = 1)
+        num_neigh_highest_FIP = len(SFs_of_first_grains)
+    
+
+        average_of_max_SF_of_all_grains[ppp] = np.mean(SFs_of_first_grains)
+        
+        
+    fig = plt.figure(facecolor="white", figsize=(6, 4), dpi=1200)     
+    plt.plot(range(1, num_to_plot+1), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b',  label = 'Highest %d FIP grains' % num_to_plot, zorder = 2, marker = 'o', markersize = '4') 
+    plt.plot(range(1, num_to_plot+1), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r', label = 'First %d grains' % num_to_plot, zorder = 2, marker = 's', markersize = '4', linestyle = ':') 
+    
+    # plt.scatter(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b',  label = '%d highest FIPs' % num_to_consider, zorder = 1, s = 2) 
+    # plt.scatter(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r',  label = '%d first grains' % num_to_consider, zorder = 1, s = 2)   
+    
+    plt.legend(framealpha = 1, fontsize = '9', loc = 'best')
+    plt.grid('True', zorder = 2)
+    plt.ylim(1.4, 2.7)
+    
+    plt.xlabel('Grain ID by FIP rank')
+    plt.ylabel('Largest SF in grain / average of $1^{st}$ and $2^{nd}$ NN SFs', fontsize = '9')
+
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, 'Ratio_R3_by_grain_ID_FIP_rank_top_%d_FIPs' % num_to_consider))
+    plt.close()  
+
+
+
+
+
+
+
+
+
+
+    plot_extra_info = False
+    
+    # This section has additional functions/code available to prospective users
+    # These were written to further investigate spatial correlations between grains and the highest computed FIPs
+    if plot_extra_info:
+
+        ''' IMPORTANT!!! : In this section, consider the average values of all SFs in the neighbors! Normalize by shared surface area later! ''' 
+        
+        num_to_consider = 50
+        
+        average_of_max_neighborhood_SFs = np.zeros((num_to_consider))
+        average_of_max_SF_of_all_grains = np.zeros((num_to_consider))
+        
+        # average_of_max_SF_of_all_grains = np.max(All_grain_SFs[0:num_to_consider], axis = 1)
+        
+        for ppp in range(num_to_consider):
+        
+            ''' Do for the highest FIPs first '''
+            # Let's examine the grains around the grain with the largest FIP
+            largest_FIP_grain = int(all_data[ppp][1])
+            nearest_neighbor_grains = [rr - 1 for rr in neighbor_list[largest_FIP_grain]]
+
+            # CRUCIAL: GRAINS ARE ALSO ORIGINALLY INDEXED AT 1 !!!
+            
+            SFs_of_grains_neighboring_largest_FIP_grain = calculate_FCC_Schmid_Factors(orientations, nearest_neighbor_grains, [1,0,0])
+        
+            # Get largest Schmid Factor in the grains neighboring the largest FIP Grain
+            # np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+            # np.mean(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+        
+            num_neigh_highest_FIP = len(SFs_of_grains_neighboring_largest_FIP_grain)
+            
+            # average_of_max_neighborhood_SFs[ppp] = np.mean(np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1))
+            
+            average_of_max_neighborhood_SFs[ppp] = np.mean(SFs_of_grains_neighboring_largest_FIP_grain)
+            
+            
+            
+            ''' Now repeat for the first 100 grains! '''
+            
+            nearest_neighbor_grains_first = [rr - 1 for rr in neighbor_list[ppp]]
+            SFs_of_first_grains = calculate_FCC_Schmid_Factors(orientations, nearest_neighbor_grains_first, [1,0,0])
+            # np.max(SFs_of_first_grains, axis = 1)
+            num_neigh_highest_FIP = len(SFs_of_first_grains)
+        
+            # average_of_max_SF_of_all_grains[ppp] = np.mean(np.max(SFs_of_first_grains, axis = 1))        
+            
+            average_of_max_SF_of_all_grains[ppp] = np.mean(SFs_of_first_grains)
+            
+            
+        fig = plt.figure(facecolor="white", figsize=(7.5, 5), dpi=1200)     
+        plt.plot(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b', linestyle = ':',  label = '%d highest FIPs' % num_to_consider, zorder = 1) 
+        plt.plot(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r', linestyle = '-.', label = '%d first grains' % num_to_consider, zorder = 1) 
+        
+        # plt.scatter(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b',  label = '%d highest FIPs' % num_to_consider, zorder = 1, s = 2) 
+        # plt.scatter(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r',  label = '%d first grains' % num_to_consider, zorder = 1, s = 2)   
+        
+        plt.legend(framealpha = 1)
+        plt.grid('True', zorder = 2)
+        # plt.ylim(0.9,1.25)
+        
+        plt.xlabel('Grain ID by FIP rank')
+        plt.ylabel('Largest SF in grain / average of neighbors SFs')
+        
+        # plt.show()
+        plt.tight_layout()
+        plt.savefig(os.path.join(store_dirr, 'SF_of_neighboring_grains___average_SFs_of_neighbors_%d_FIPs' % num_to_consider))
+        plt.close()           
+        
+        
+        
+        ''' Normalize by shared surface area '''
+        
+        num_to_consider = 50
+        
+        average_of_max_neighborhood_SFs = np.zeros((num_to_consider))
+        average_of_max_SF_of_all_grains = np.zeros((num_to_consider))
+        
+        # average_of_max_SF_of_all_grains = np.max(All_grain_SFs[0:num_to_consider], axis = 1)
+        
+        for ppp in range(num_to_consider):
+        
+            ''' Do for the highest FIPs first '''
+            # Let's examine the grains around the grain with the largest FIP
+            largest_FIP_grain = int(all_data[ppp][1])
+            nearest_neighbor_grains = [rr - 1 for rr in neighbor_list[largest_FIP_grain]]
+
+            # CRUCIAL: GRAINS ARE ALSO ORIGINALLY INDEXED AT 1 !!!
+            
+            SFs_of_grains_neighboring_largest_FIP_grain = calculate_FCC_Schmid_Factors(orientations, nearest_neighbor_grains, [1,0,0])
+        
+            # Get largest Schmid Factor in the grains neighboring the largest FIP Grain
+            # np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+            # np.mean(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+        
+            num_neigh_highest_FIP = len(SFs_of_grains_neighboring_largest_FIP_grain)
+            
+            # average_of_max_neighborhood_SFs[ppp] = np.mean(np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1))
+            
+            ''' Get shared area for this grain's neighbors: '''
+            
+            shared_area_btw_grain_and_neighbors = shared_surface_area_list[largest_FIP_grain]
+            total_area = np.sum(shared_area_btw_grain_and_neighbors)
+            
+            normalized_SFs = np.zeros((num_neigh_highest_FIP,12))
+            
+            for ii in range(num_neigh_highest_FIP):
+                normalized_SFs[ii] = (SFs_of_grains_neighboring_largest_FIP_grain[ii] * shared_area_btw_grain_and_neighbors[ii]) / total_area
+            
+            average_of_max_neighborhood_SFs[ppp] = np.mean(normalized_SFs)
+            
+            
+            
+            ''' Now repeat for the first 100 grains! '''
+            
+            nearest_neighbor_grains_first = [rr - 1 for rr in neighbor_list[ppp]]
+            SFs_of_first_grains = calculate_FCC_Schmid_Factors(orientations, nearest_neighbor_grains_first, [1,0,0])
+            num_neigh_highest_FIP_first_x_grains = len(SFs_of_first_grains)
+            
+            
+            shared_area_btw_first_x_Grains = shared_surface_area_list[ppp]
+            total_area_first_x_Grains = np.sum(shared_area_btw_first_x_Grains)
+            
+            normalized_SFs_first_x_grains = np.zeros((num_neigh_highest_FIP_first_x_grains,12))
+        
+            for ii in range(num_neigh_highest_FIP_first_x_grains):
+                normalized_SFs_first_x_grains[ii] = (SFs_of_first_grains[ii] * shared_area_btw_first_x_Grains[ii]) / total_area_first_x_Grains
+            
+            average_of_max_SF_of_all_grains[ppp] = np.mean(normalized_SFs_first_x_grains)
+            
+            
+        fig = plt.figure(facecolor="white", figsize=(7.5, 5), dpi=1200)     
+        plt.plot(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b', linestyle = ':',  label = '%d highest FIPs' % num_to_consider, zorder = 1) 
+        plt.plot(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r', linestyle = '-.', label = '%d first grains' % num_to_consider, zorder = 1) 
+        
+        # plt.scatter(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b',  label = '%d highest FIPs' % num_to_consider, zorder = 1, s = 2) 
+        # plt.scatter(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r',  label = '%d first grains' % num_to_consider, zorder = 1, s = 2)   
+        
+        plt.legend(framealpha = 1)
+        plt.grid('True', zorder = 2)
+        # plt.ylim(0.9,1.25)
+        
+        plt.xlabel('Grain ID by FIP rank')
+        plt.ylabel('Largest SF in grain / surface area weighted average of neighbors SFs')
+        
+        # plt.show()
+        plt.tight_layout()
+        plt.savefig(os.path.join(store_dirr, 'SF_of_neighboring_grains___WEIGHTED_average_SFs_of_neighbors_%d_FIPs' % num_to_consider))
+        plt.close()  
+        
+
+        
+        ''' Normalize by shared surface area and volume of neighbor '''
+        
+        num_to_consider = 50
+        
+        average_of_max_neighborhood_SFs = np.zeros((num_to_consider))
+        average_of_max_SF_of_all_grains = np.zeros((num_to_consider))
+        
+        # average_of_max_SF_of_all_grains = np.max(All_grain_SFs[0:num_to_consider], axis = 1)
+        
+        for ppp in range(num_to_consider):
+        
+            ''' Do for the highest FIPs first '''
+            # Let's examine the grains around the grain with the largest FIP
+            largest_FIP_grain = int(all_data[ppp][1])
+            nearest_neighbor_grains = [rr - 1 for rr in neighbor_list[largest_FIP_grain]]
+
+            # CRUCIAL: GRAINS ARE ALSO ORIGINALLY INDEXED AT 1 !!!
+            
+            SFs_of_grains_neighboring_largest_FIP_grain = calculate_FCC_Schmid_Factors(orientations, nearest_neighbor_grains, [1,0,0])
+        
+            # Get largest Schmid Factor in the grains neighboring the largest FIP Grain
+            # np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+            # np.mean(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+        
+            num_neigh_highest_FIP = len(SFs_of_grains_neighboring_largest_FIP_grain)
+            
+            # average_of_max_neighborhood_SFs[ppp] = np.mean(np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1))
+            
+            ''' Get shared area for this grain's neighbors: '''
+            
+            shared_area_btw_grain_and_neighbors = shared_surface_area_list[largest_FIP_grain]
+            total_area = np.sum(shared_area_btw_grain_and_neighbors)
+            
+            neighbor_volumes = volumes[nearest_neighbor_grains]
+            total_volume = np.sum(neighbor_volumes)
+            
+            normalized_SFs = np.zeros((num_neigh_highest_FIP,12))
+            
+            for ii in range(num_neigh_highest_FIP):
+                normalized_SFs[ii] = (SFs_of_grains_neighboring_largest_FIP_grain[ii] * neighbor_volumes[ii] * shared_area_btw_grain_and_neighbors[ii]) / (total_volume*total_area)
+            
+            average_of_max_neighborhood_SFs[ppp] = np.mean(normalized_SFs)
+            
+            
+            
+            ''' Now repeat for the first 100 grains! '''
+            
+            nearest_neighbor_grains_first = [rr - 1 for rr in neighbor_list[ppp]]
+            SFs_of_first_grains = calculate_FCC_Schmid_Factors(orientations, nearest_neighbor_grains_first, [1,0,0])
+            num_neigh_highest_FIP_first_x_grains = len(SFs_of_first_grains)
+            
+            
+            shared_area_btw_first_x_Grains = shared_surface_area_list[ppp]
+            total_area_first_x_Grains = np.sum(shared_area_btw_first_x_Grains)
+            
+            
+            neighbor_volumes_first_x_Grains = volumes[nearest_neighbor_grains_first]
+            total_volume_first_x_Grains = np.sum(neighbor_volumes_first_x_Grains)
+            
+            
+            normalized_SFs_first_x_grains = np.zeros((num_neigh_highest_FIP_first_x_grains,12))
+        
+            for ii in range(num_neigh_highest_FIP_first_x_grains):
+                normalized_SFs_first_x_grains[ii] = (SFs_of_first_grains[ii] * neighbor_volumes_first_x_Grains[ii] * shared_area_btw_first_x_Grains[ii]) / (total_volume_first_x_Grains*total_area_first_x_Grains)
+            
+            average_of_max_SF_of_all_grains[ppp] = np.mean(normalized_SFs_first_x_grains)
+            
+            
+        fig = plt.figure(facecolor="white", figsize=(7.5, 5), dpi=1200)     
+        plt.plot(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b', linestyle = ':',  label = '%d highest FIPs' % num_to_consider, zorder = 1) 
+        plt.plot(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r', linestyle = '-.', label = '%d first grains' % num_to_consider, zorder = 1) 
+        
+        # plt.scatter(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b',  label = '%d highest FIPs' % num_to_consider, zorder = 1, s = 2) 
+        # plt.scatter(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r',  label = '%d first grains' % num_to_consider, zorder = 1, s = 2)   
+        
+        plt.legend(framealpha = 1)
+        plt.grid('True', zorder = 2)
+        # plt.ylim(0.9,1.25)
+        
+        plt.xlabel('Grain ID by FIP rank')
+        plt.ylabel('Largest SF in grain / surface area weighted average of neighbors SFs')
+        
+        # plt.show()
+        plt.tight_layout()
+        plt.savefig(os.path.join(store_dirr, 'SF_of_neighboring_grains___WEIGHTED_average_SFs_of_neighbors_with_volume_%d_FIPs' % num_to_consider))
+        plt.close()  
+
+
+
+        ''' Expand to 2nd nearest neighbor grains ''' 
+        # all_data variable is indexed at 0 !
+        # neighbor_list variable is indexed at 1 so need to subtract 1 !
+
+        num_to_consider = 50
+        avg = True
+        
+        average_of_max_neighborhood_SFs = np.zeros((num_to_consider))
+        average_of_max_SF_of_all_grains = np.zeros((num_to_consider))
+        
+        # average_of_max_SF_of_all_grains = np.max(All_grain_SFs[0:num_to_consider], axis = 1)
+        
+        for ppp in range(num_to_consider):
+        
+            ''' Do for the highest FIPs first '''
+            # Let's examine the grains around the grain with the largest FIP
+            largest_FIP_grain = int(all_data[ppp][1])
+            nearest_neighbor_grains = [rr - 1 for rr in neighbor_list[largest_FIP_grain]]
+            
+            second_nearest_neighbor_grains = []
+            
+            for neighbors_1 in nearest_neighbor_grains:
+                second_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+
+            flat_2nd_neighbors = list(flatten(second_nearest_neighbor_grains))
+           
+
+             
+            # CRUCIAL: GRAINS ARE ALSO ORIGINALLY INDEXED AT 1 !!!
+            
+            SFs_of_grains_neighboring_largest_FIP_grain = calculate_FCC_Schmid_Factors(orientations, flat_2nd_neighbors, [1,0,0])
+        
+            # Get largest Schmid Factor in the grains neighboring the largest FIP Grain
+            # np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+            # np.mean(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+        
+            num_neigh_highest_FIP = len(SFs_of_grains_neighboring_largest_FIP_grain)
+            
+            if not avg:
+                average_of_max_neighborhood_SFs[ppp] = np.mean(np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1))
+            else:
+                average_of_max_neighborhood_SFs[ppp] = np.mean(SFs_of_grains_neighboring_largest_FIP_grain)
+            
+            print(num_neigh_highest_FIP)
+            ''' Now repeat for the first 100 grains! '''
+            
+            nearest_neighbor_grains_first = [rr - 1 for rr in neighbor_list[ppp]]
+            
+            
+            second_nearest_neighbor_grains_first_X_grains = []
+            
+            for neighbors_1 in nearest_neighbor_grains_first:
+                second_nearest_neighbor_grains_first_X_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+
+            flat_2nd_neighbors_first_x_Grains = list(flatten(second_nearest_neighbor_grains_first_X_grains))            
+
+            
+            SFs_of_first_grains = calculate_FCC_Schmid_Factors(orientations, flat_2nd_neighbors_first_x_Grains, [1,0,0])
+            # np.max(SFs_of_first_grains, axis = 1)
+            num_neigh_highest_FIP = len(SFs_of_first_grains)
+        
+            if not avg:
+                average_of_max_SF_of_all_grains[ppp] = np.mean(np.max(SFs_of_first_grains, axis = 1))        
+            else:
+                average_of_max_SF_of_all_grains[ppp] = np.mean(SFs_of_first_grains)
+            
+            
+        fig = plt.figure(facecolor="white", figsize=(7.5, 5), dpi=1200)     
+        plt.plot(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b', linestyle = ':',  label = '%d highest FIPs' % num_to_consider, zorder = 1) 
+        plt.plot(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r', linestyle = '-.', label = '%d first grains' % num_to_consider, zorder = 1) 
+        
+        # plt.scatter(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b',  label = '%d highest FIPs' % num_to_consider, zorder = 1, s = 2) 
+        # plt.scatter(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r',  label = '%d first grains' % num_to_consider, zorder = 1, s = 2)   
+        
+        plt.legend(framealpha = 1)
+        plt.grid('True', zorder = 2)
+        # plt.ylim(0.9,1.25)
+        
+        plt.xlabel('Grain ID by FIP rank')
+        if not avg:
+            plt.ylabel('Largest SF in grain / average of max of neighbors SFs')
+        else:
+            plt.ylabel('Largest SF in grain / average of neighbors SFs')
+        
+        # plt.show()
+        plt.tight_layout()
+        if not avg:
+            plt.savefig('SF_of_neighboring_grains___average_of_max_SFs_of_neighbors_%d_2nd_nearest.png' % num_to_consider)
+        else:
+            plt.savefig('SF_of_neighboring_grains___average_SFs_of_neighbors_%d_2nd_nearest.png' % num_to_consider)
+        plt.close()           
+
+
+
+        ''' Expand to 3rd nearest neighbor grains ''' 
+        # all_data variable is indexed at 0 !
+        # neighbor_list variable is indexed at 1 so need to subtract 1 !
+
+        num_to_consider = 50
+        avg = False
+        
+        average_of_max_neighborhood_SFs = np.zeros((num_to_consider))
+        average_of_max_SF_of_all_grains = np.zeros((num_to_consider))
+        
+        # average_of_max_SF_of_all_grains = np.max(All_grain_SFs[0:num_to_consider], axis = 1)
+        
+        for ppp in range(num_to_consider):
+        
+            ''' Do for the highest FIPs first '''
+            # Let's examine the grains around the grain with the largest FIP
+            largest_FIP_grain = int(all_data[ppp][1])
+            nearest_neighbor_grains = [rr - 1 for rr in neighbor_list[largest_FIP_grain]]
+            
+            second_nearest_neighbor_grains = []
+            
+            for neighbors_1 in nearest_neighbor_grains:
+                second_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+
+            flat_2nd_neighbors = list(flatten(second_nearest_neighbor_grains))
+            
+            
+            third_nearest_neighbor_grains = []
+            
+            for neighbors_1 in flat_2nd_neighbors:
+                third_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+
+            flat_3rd_neighbors = list(flatten(third_nearest_neighbor_grains))            
+            
+            
+            
+             
+            # CRUCIAL: GRAINS ARE ALSO ORIGINALLY INDEXED AT 1 !!!
+            
+            SFs_of_grains_neighboring_largest_FIP_grain = calculate_FCC_Schmid_Factors(orientations, flat_3rd_neighbors, [1,0,0])
+        
+            # Get largest Schmid Factor in the grains neighboring the largest FIP Grain
+            # np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+            # np.mean(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1)
+        
+            num_neigh_highest_FIP = len(SFs_of_grains_neighboring_largest_FIP_grain)
+            
+            if not avg:
+                average_of_max_neighborhood_SFs[ppp] = np.mean(np.max(SFs_of_grains_neighboring_largest_FIP_grain, axis = 1))
+            else:
+                average_of_max_neighborhood_SFs[ppp] = np.mean(SFs_of_grains_neighboring_largest_FIP_grain)
+            
+
+            ''' Now repeat for the first 100 grains! '''
+            
+            nearest_neighbor_grains_first = [rr - 1 for rr in neighbor_list[ppp]]
+            
+            
+            second_nearest_neighbor_grains_first_X_grains = []
+            
+            for neighbors_1 in nearest_neighbor_grains_first:
+                second_nearest_neighbor_grains_first_X_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+
+            flat_2nd_neighbors_first_x_Grains = list(flatten(second_nearest_neighbor_grains_first_X_grains))            
+            
+            
+            third_nearest_neighbor_grains_first_X_grains = []
+            
+            for neighbors_1 in flat_2nd_neighbors_first_x_Grains:
+                third_nearest_neighbor_grains_first_X_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+
+            flat_3rd_neighbors_first_x_Grains = list(flatten(third_nearest_neighbor_grains_first_X_grains))                
+            
+            
+            
+            
+            SFs_of_first_grains = calculate_FCC_Schmid_Factors(orientations, flat_3rd_neighbors_first_x_Grains, [1,0,0])
+            # np.max(SFs_of_first_grains, axis = 1)
+            num_neigh_highest_FIP = len(SFs_of_first_grains)
+            
+
+            
+            if not avg:
+                average_of_max_SF_of_all_grains[ppp] = np.mean(np.max(SFs_of_first_grains, axis = 1))        
+            else:
+                average_of_max_SF_of_all_grains[ppp] = np.mean(SFs_of_first_grains)
+            
+            
+        fig = plt.figure(facecolor="white", figsize=(7.5, 5), dpi=1200)     
+        plt.plot(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b', linestyle = ':',  label = '%d highest FIPs' % num_to_consider, zorder = 1) 
+        plt.plot(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r', linestyle = '-.', label = '%d first grains' % num_to_consider, zorder = 1) 
+        
+        # plt.scatter(range(num_to_consider), SF_of_highest_FIPs[0:num_to_consider]/average_of_max_neighborhood_SFs, c = 'b',  label = '%d highest FIPs' % num_to_consider, zorder = 1, s = 2) 
+        # plt.scatter(range(num_to_consider), np.max(All_grain_SFs[0:num_to_consider],axis = 1)/average_of_max_SF_of_all_grains, c = 'r',  label = '%d first grains' % num_to_consider, zorder = 1, s = 2)   
+        
+        plt.legend(framealpha = 1)
+        plt.grid('True', zorder = 2)
+        # plt.ylim(0.9,1.25)
+        
+        plt.xlabel('Grain ID by FIP rank')
+        if not avg:
+            plt.ylabel('Largest SF in grain / average of max of neighbors SFs')
+        else:
+            plt.ylabel('Largest SF in grain / average of neighbors SFs')
+        
+        # plt.show()
+        plt.tight_layout()
+        if not avg:
+            plt.savefig(os.path.join(store_dirr, 'SF_of_neighboring_grains___average_of_max_SFs_of_neighbors_%d_3rd_nearest' % num_to_consider))
+        else:
+            plt.savefig(os.path.join(store_dirr, 'SF_of_neighboring_grains___average_SFs_of_neighbors_%d_3rd_nearest_%d_FIPs' % num_to_consider))
+        plt.close()           
+
+
+        
+        # elements indexed at 0 as read in below!
+        fname = 'element_grain_sets_0.p'
+        h1 = open(os.path.join(directory, fname),'rb')
+        grain_sets = p.load(h1)
+        h1.close()        
+     
+
+        
+        ''' 12 / 8 / 20: let's plot grain centroids and plastic shear strain range... '''
+        grain_averaged_fips = np.zeros(len(grain_sets))
+        max_PSS_per_elem = np.max(plastic_shear_strain_range_FIP, axis = 1)
+
+        for ii, elems in enumerate(grain_sets):
+            grain_averaged_fips[ii] = np.mean(max_PSS_per_elem[elems])   
+
+
+
+        ''' Plot Schmid Factors ... '''
+        for plot_me_plz in range(20):
+            highest_fip_grain_index = plot_me_plz    
+            #highest_fip_grain_index = 2
+            
+            highest_FIP_grain = int(all_data[highest_fip_grain_index][1])
+            
+            nearest_neighbor_grains = [rr - 1 for rr in neighbor_list[highest_FIP_grain]]
+            
+            x_cen = centroids[nearest_neighbor_grains].transpose()[0]
+            y_cen = centroids[nearest_neighbor_grains].transpose()[1]
+            z_cen = centroids[nearest_neighbor_grains].transpose()[2]
+         
+            # Get second nearest neighbors
+            second_nearest_neighbor_grains = []
+            for neighbors_1 in nearest_neighbor_grains:
+                second_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+                
+            flat_second = list(flatten(second_nearest_neighbor_grains))
+            
+            unique_second = []
+            
+            for item4 in flat_second:
+                if item4 not in nearest_neighbor_grains:
+                    unique_second.append(item4)
+            
+            unique_second.remove(highest_FIP_grain)
+         
+            x_cen_2nd = centroids[unique_second].transpose()[0]
+            y_cen_2nd = centroids[unique_second].transpose()[1]
+            z_cen_2nd = centroids[unique_second].transpose()[2]    
+         
+         
+         
+            All_grain_SFs = calculate_FCC_Schmid_Factors(orientations, [x for x in range(len(orientations))], [1,0,0])
+         
+            ''' f'''
+            #     cvals  = [-2., -1, 2]
+            #     colors = ["red","violet","blue"]
+
+            #     norm=plt.Normalize(min(cvals),max(cvals))
+            #     tuples = list(zip(map(norm,cvals), colors))
+            #     cmap = matplotlib.colors.LinearSegmentedColormap.from_list("", tuples)   
+            
+            
+            fig = plt.figure(figsize=(16,10))
+            ax = fig.add_subplot(111, projection='3d')
+            
+            cm = plt.cm.get_cmap('cool')
+            
+            p = ax.scatter(centroids[highest_FIP_grain][0], centroids[highest_FIP_grain][1], centroids[highest_FIP_grain][2], s = 200, c = [SF_of_highest_FIPs[highest_fip_grain_index]], marker = '^', label = 'Grain %d' % (int(all_data[highest_fip_grain_index][1]) + 1), cmap = cm, vmin = 0.4, vmax = 0.5)
+            p = ax.scatter(x_cen, y_cen, z_cen, c = np.max(All_grain_SFs[nearest_neighbor_grains],axis = 1), marker = 'o', s = 200, label = '1st nearest neighbors', cmap = cm, vmin = 0.4, vmax = 0.5)
+            # p = ax.scatter(x_cen_2nd, y_cen_2nd, z_cen_2nd, c = np.max(All_grain_SFs[unique_second],axis = 1), marker = 's', s = 200, label = '2nd nearest neighbors', cmap = cm)
+            
+            cbar = plt.colorbar(p)
+            cbar.set_label("Max SF")
+            
+            # ax.scatter(layer_3_step_0_COM.transpose()[0], layer_3_step_0_COM.transpose()[1], layer_3_step_0_COM.transpose()[2], c='g', label = 'Layer 3')
+            # ax.scatter(layer_4_step_0_COM.transpose()[0], layer_4_step_0_COM.transpose()[1], layer_4_step_0_COM.transpose()[2], c='r', label = 'Layer 4')
+            
+            ax.set_xlabel('X')
+            ax.set_ylabel('Y')
+            ax.set_zlabel('Z')
+            ax.legend()
+            plt.tight_layout()
+
+            # plt.savefig('all_layer_3_grains.png')
+            # plt.savefig('neighbors_surrounding_grain_index_%d_max_Schmid_factors_0.4_to_0.5.png' % plot_me_plz)
+            plt.show()
+            plt.close()   
+            
+            
+
+
+        ''' Plot grain averaged plastic shear strain range '''
+        
+        for plot_me_plz in range(2):
+            highest_fip_grain_index = plot_me_plz
+            
+            highest_FIP_grain = int(all_data[highest_fip_grain_index][1])
+            
+            nearest_neighbor_grains = [rr - 1 for rr in neighbor_list[highest_FIP_grain]]
+            
+            x_cen = centroids[nearest_neighbor_grains].transpose()[0]
+            y_cen = centroids[nearest_neighbor_grains].transpose()[1]
+            z_cen = centroids[nearest_neighbor_grains].transpose()[2]
+         
+            # Get second nearest neighbors
+            second_nearest_neighbor_grains = []
+            for neighbors_1 in nearest_neighbor_grains:
+                second_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+                
+            flat_second = list(flatten(second_nearest_neighbor_grains))
+            
+            unique_second = []
+            
+            for item4 in flat_second:
+                if item4 not in nearest_neighbor_grains:
+                    unique_second.append(item4)
+            
+            unique_second.remove(highest_FIP_grain)
+         
+            x_cen_2nd = centroids[unique_second].transpose()[0]
+            y_cen_2nd = centroids[unique_second].transpose()[1]
+            z_cen_2nd = centroids[unique_second].transpose()[2]    
+         
+         
+         
+            All_grain_SFs = calculate_FCC_Schmid_Factors(orientations, [x for x in range(len(orientations))], [1,0,0])
+         
+            ''' f'''
+            #     cvals  = [-2., -1, 2]
+            #     colors = ["red","violet","blue"]
+
+            #     norm=plt.Normalize(min(cvals),max(cvals))
+            #     tuples = list(zip(map(norm,cvals), colors))
+            #     cmap = matplotlib.colors.LinearSegmentedColormap.from_list("", tuples)   
+            
+            
+            fig = plt.figure(figsize=(16,10))
+            ax = fig.add_subplot(111, projection='3d')
+            
+            cm = plt.cm.get_cmap('cool')
+            
+            p = ax.scatter(centroids[highest_FIP_grain][0], centroids[highest_FIP_grain][1], centroids[highest_FIP_grain][2], s = 200, c = [grain_averaged_fips[int(all_data[highest_fip_grain_index][1])]], marker = '^', label = 'Grain %d' % (int(all_data[highest_fip_grain_index][1]) + 1), cmap = cm, vmin=np.min(grain_averaged_fips[nearest_neighbor_grains]), vmax=grain_averaged_fips[int(all_data[highest_fip_grain_index][1])])
+            p = ax.scatter(x_cen, y_cen, z_cen, c = grain_averaged_fips[nearest_neighbor_grains], marker = 'o', s = 200, label = '1st nearest neighbors', cmap = cm, vmin=np.min(grain_averaged_fips[nearest_neighbor_grains]), vmax=grain_averaged_fips[int(all_data[highest_fip_grain_index][1])])
+            # p = ax.scatter(x_cen_2nd, y_cen_2nd, z_cen_2nd, c = np.max(All_grain_SFs[unique_second],axis = 1), marker = 's', s = 200, label = '2nd nearest neighbors', cmap = cm)
+            
+            cbar = plt.colorbar(p)
+            cbar.set_label("Grain averaged maximum plastic shear strain range")
+            
+            # ax.scatter(layer_3_step_0_COM.transpose()[0], layer_3_step_0_COM.transpose()[1], layer_3_step_0_COM.transpose()[2], c='g', label = 'Layer 3')
+            # ax.scatter(layer_4_step_0_COM.transpose()[0], layer_4_step_0_COM.transpose()[1], layer_4_step_0_COM.transpose()[2], c='r', label = 'Layer 4')
+            
+            ax.set_xlabel('X')
+            ax.set_ylabel('Y')
+            ax.set_zlabel('Z')
+            ax.legend()
+            plt.tight_layout()
+
+            # plt.savefig('neighbors_surrounding_grain_index_%d.png' % plot_me_plz)
+            plt.show()
+            plt.close()   
+        
+
+        # Other quick calculations
+        # "Lowest" possible SFs when pulling along the [111] direction
+        # calculate_FCC_Schmid_Factors(np.zeros((2,3)),[0],[1,1,1]/np.sqrt(3))
+        
+        # straing along [100] direction:
+        # calculate_FCC_Schmid_Factors(np.zeros((2,3)),[0],[1,0,0])
+    
+    
+def main():
+    # Plot correlations
+    compute_correlations()
+    
+    # Visualize the top 50 FIP grains
+    top_50_FIPs_vtk()
+
+if __name__ == "__main__":
+    main()
+   

--- a/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_compile_FIPs.py
+++ b/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_compile_FIPs.py
@@ -1,0 +1,653 @@
+import os
+import numpy as np
+import scipy.stats as ss
+import sklearn.metrics as sm
+import sys
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.pylab as plt_cols
+import matplotlib.cm as cm
+import scipy.ndimage.filters as filters
+import pandas as pd
+import matplotlib.ticker as ticker
+import operator
+import glob
+import pickle as p
+import scipy
+import re
+from statsmodels.distributions.empirical_distribution import ECDF
+import matplotlib.ticker as mtick
+
+# Get name of directory that contains the PRISMS-Fatigue scripts
+DIR_LOC = os.path.dirname(os.path.abspath(__file__))
+
+locats_Al7075_compare_shape_7500_grain = [os.path.join(DIR_LOC, r'Section_3\7500_grain\7500_grain_cubic_equiaxed'),
+                                          os.path.join(DIR_LOC, r'Section_3\7500_grain\7500_grain_cubic_elongated'),
+                                          os.path.join(DIR_LOC, r'Section_3\7500_grain\7500_grain_random_equiaxed'),
+                                          os.path.join(DIR_LOC, r'Section_3\7500_grain\7500_grain_random_elongated'),
+                                          os.path.join(DIR_LOC, r'Section_3\7500_grain\7500_grain_rolled_equiaxed'),
+                                          os.path.join(DIR_LOC, r'Section_3\7500_grain\7500_grain_rolled_elongated')]  
+
+locats_Al7075_compare_shape_41000_grain = [os.path.join(DIR_LOC, r'Section_3\41000_grain\41000_grain_cubic_equiaxed'),
+                                           os.path.join(DIR_LOC, r'Section_3\41000_grain\41000_grain_cubic_elongated'),
+                                           os.path.join(DIR_LOC, r'Section_3\41000_grain\41000_grain_random_equiaxed'),
+                                           os.path.join(DIR_LOC, r'Section_3\41000_grain\41000_grain_random_elongated'),
+                                           os.path.join(DIR_LOC, r'Section_3\41000_grain\41000_grain_rolled_equiaxed'),
+                                           os.path.join(DIR_LOC, r'Section_3\41000_grain\41000_grain_rolled_elongated')]  
+
+locats_Al7075_convergence = [os.path.dirname(DIR_LOC) + '/compile/random_periodic_equiaxed_90^3_22_total',
+                             os.path.dirname(DIR_LOC) + '/compile/random_periodic_equiaxed_160^3_4_total',
+                             os.path.dirname(DIR_LOC) + '/compile/random_periodic_equiaxed_200^3_2_total',
+                             os.path.dirname(DIR_LOC) + '/compile/random_periodic_equiaxed_250^3_1_total']    
+
+locats_Al7075_convergence = [os.path.join(DIR_LOC, r'Section_4\7500_x_22'),
+                             os.path.join(DIR_LOC, r'Section_4\41000_x_4'),
+                             os.path.join(DIR_LOC, r'Section_4\80000_x_2'),
+                             os.path.join(DIR_LOC, r'Section_4\160000_x_1')]  
+
+pad_dist = 12
+font_size = 8
+tick_widths = 1
+tick_lens = 5
+
+
+def read_FIPs_from_single_SVE(directory, num, num_fips_extract):
+    # Additional unused function to read in the largest sub-band averaged FIPs (one per grain) from a single microstructure instantiation
+    # This is particularly useful when considering a very large SVE with more than ~10,000 grains as this function can take a long time!
+    # Go to directory
+    
+    tmp_dir = os.getcwd()
+    os.chdir(directory)
+    
+    # Specify name of pickle file with sub-band averaged FIPs
+    fname = 'sub_band_averaged_FS_FIP_pickle_%d.p' % num    
+    
+    # Specify how many of the highest FIPs per grain should be imported. Typically, only the few hundred highest FIPs are of interest
+    # This significantly speeds up this algorithm!
+    # IMPORTANT: If th is is set below the number of grains in the instantiation, the function will fail! 
+    
+    # Initialize list of just FIPs
+    new_all_fs_fips = []
+
+    # Initialize list to keep track of which grains have already been considered
+    added_g = []
+    
+    # Read in FIPs
+    h1 = open(fname,'rb')
+    fips = p.load(h1, encoding = 'latin1')
+    h1.close()
+    
+    # Sort in descending order
+    sorted_fips = sorted(fips.items(), key=operator.itemgetter(1))
+    sorted_fips.reverse()
+    
+    # Initialize array with more detailed FIP data
+    # FIP, grain number, slip system number, layer number, sub-band region number
+    all_data = np.zeros((num_fips_extract,5))
+    
+    # Main counter
+    nn = 0
+    
+    # Track counter
+    mm = 0    
+    
+    while len(added_g) < num_fips_extract:
+    
+        if sorted_fips[nn][0][0] not in added_g:
+            added_g.append(sorted_fips[nn][0][0])
+            
+            all_data[mm][0] = sorted_fips[nn][1]
+            all_data[mm][1] = sorted_fips[nn][0][0]
+            all_data[mm][2] = sorted_fips[nn][0][1]
+            all_data[mm][3] = sorted_fips[nn][0][2]
+            all_data[mm][4] = sorted_fips[nn][0][3]
+            mm += 1
+            new_all_fs_fips.append(sorted_fips[nn][1])
+            # print(mm)
+        nn += 1     
+    
+    os.chdir(tmp_dir)
+    return new_all_fs_fips
+    # return new_all_fs_fips, all_data, added_g 
+
+def read_pickled_SBA_FIPs(directory, num_fips_extract, FIP_type, averaging_type):
+    # Read in FIPs from one batch folder
+    
+    # Go to directory
+    tmp_dir = os.getcwd()
+    os.chdir(directory)
+    
+    # Find all pickle files with FIPs
+    file_names = []
+    
+    # Specify type of desired FIP averaging to plot
+    if averaging_type == 'sub_band':
+        # fname = 'prisms_sub_band_averaged_FIPs_form_pickled*'
+        fname = 'sub_band_averaged_%s_pickle*' % FIP_type
+    elif averaging_type == 'band':
+        fname = 'band_averaged_%s_pickle*' % FIP_type
+    elif averaging_type == 'grain':
+        fname = 'grain_averaged_%s_pickle*' % FIP_type
+    else:
+        raise ValueError('Unknown input! Please ensure averaging_type is "sub_band", "band", or "grain"!')
+    
+    for Name in glob.glob(fname):
+        file_names.append(Name)
+       
+    # Make sure the desired files exist in this folder, i.e., that the FIPs have been volume averaged as desired
+    if len(file_names) == 0:
+        raise ValueError('No FIP files detected! Please double check settings!')
+    
+    print('Currently in %s' % directory)  
+    
+    # Initialize list to store FIPs
+    new_all_fs_fips = []
+    
+    # Sub-band and band averaged FIPs are extracted in the same fashion
+    if averaging_type == 'sub_band' or averaging_type == 'band':
+    
+        # Iterate through all pickle FIP files
+        for fip_file in file_names:
+        
+            # Extract the single highest FIP per grain
+            added_g = []
+            
+            # Read in FIPs
+            fname1 = os.path.join(os.getcwd(), fip_file)
+            h1 = open(fname1,'rb')
+            fips = p.load(h1)
+            h1.close()
+            print(fip_file)
+            
+            sorted_fips = sorted(fips.items(), key=operator.itemgetter(1))
+            sorted_fips.reverse()
+            
+            # Iterate through all FIPs, extract the maximum SBA FIP per grain
+            for nn in range(len(sorted_fips)):
+                if sorted_fips[nn][0][0] not in added_g:
+                    added_g.append(sorted_fips[nn][0][0])
+                    new_all_fs_fips.append(sorted_fips[nn][1])
+
+        new_all_fs_fips.sort(reverse=True)
+        os.chdir(tmp_dir)    
+        return new_all_fs_fips[0:num_fips_extract]
+        
+    elif averaging_type == 'grain':    
+        
+        new_all_fs_fips = np.asarray(())
+        
+        # Iterate through all pickle FIP files
+        for fip_file in file_names:
+        
+            # Read in FIPs
+            fname1 = os.path.join(os.getcwd(), fip_file)
+            h1 = open(fname1,'rb')
+            fips = p.load(h1)
+            h1.close()
+            print(fip_file)
+            
+            # Append entire list of FIPs to the main list since these are already the largest FIPs per grain
+            new_all_fs_fips = np.append(new_all_fs_fips, fips)
+         
+        all_sorted_grain_FIPs = np.sort(new_all_fs_fips)[::-1]
+        os.chdir(tmp_dir)    
+        return all_sorted_grain_FIPs[0:num_fips_extract]    
+   
+def plot_FIPS(base_directory, plt_type, mat, num_fips_plot, FIP_type, averaging_type, num_plot_variation, save_fig = True):
+    # Function to plot FIPs from bulk (i.e., fully periodic) and surface (i.e., traction-free/free surface) simulations, or other types of simulations
+    print('Plotting volume averaged FIPs')
+    os.chdir(base_directory)
+
+    # Specify which FIPS to plot
+    
+    # Compare FIPs from microstructures with ~7,500 grains
+    if mat == '7500_grain_compare_shape':
+        # Names to use for figure legend
+        names = ["Cubic Equiaxed", "Cubic Elongated", "Random Equiaxed", "Random Elongated", "Rolled Equiaxed", "Rolled Elongated"]
+        
+        # Locations of FIP files
+        locs = locats_Al7075_compare_shape_7500_grain
+        
+        # Number of columns for figure legend
+        plot_col = 1
+        
+        # Marker colors
+        cfm = ['r','r','b','b','g','g']
+        
+        # Marker shapes
+        sfm = ['o','o','s','s','^','^']   
+        
+        # If True, every other FIP dataset will be plotted with hollow markers
+        hollow_and_full = True
+        
+        # Plot to show variability?
+        variability = False
+        
+    # Compare FIPs from microstructures with ~41,000 grains
+    elif mat == '41000_grain_compare_shape':
+        # Names to use for figure legend
+        names = ["Cubic Equiaxed", "Cubic Elongated", "Random Equiaxed", "Random Elongated", "Rolled Equiaxed", "Rolled Elongated"]
+        
+        # Locations of FIP files
+        locs = locats_Al7075_compare_shape_41000_grain
+        
+        # Number of columns for figure legend
+        plot_col = 1
+        
+        # Marker colors
+        cfm = ['r','r','b','b','g','g']
+        
+        # Marker shapes
+        sfm = ['o','o','s','s','^','^']   
+        
+        # If True, every other FIP dataset will be plotted with hollow markers
+        hollow_and_full = True
+        
+        # Plot to show variability?
+        variability = False
+        
+    # Plot FIPs from the four ensembles, each with a total of ~160,000 grains
+    elif mat == 'Al7075_convergence':
+        
+        # Names to use for figure legend
+        names = ['~7,500     grains x 22 SVEs', '~41,000   grains x   4 SVEs', '~80,000   grains x   2 SVEs', '~161,000 grains x   1 SVE']
+        
+        # Locations of FIP files
+        locs = locats_Al7075_convergence
+        
+        # Number of columns for figure legend
+        plot_col = 1
+        
+        # Marker colors
+        cfm = ['r','b','g','m']
+        
+        # Marker shapes
+        sfm = ['s','o','^','*']   
+        
+        # If True, every other FIP dataset will be plotted with hollow markers
+        hollow_and_full = False   
+        
+        # Plot to show variability?
+        variability = False
+    
+    # Plot the variability in the 90^3 simulations
+    elif mat == '7500_variation':
+    
+        # Names to use for figure legend
+        names = ['~7,500 grains x %d SVEs' % num_plot_variation]
+        
+        # Locations of FIP files
+        locs = locats_Al7075_convergence[0]
+        
+        # Number of columns for figure legend
+        plot_col = 1
+        
+        # Marker colors
+        cfm = plt_cols.cm.Reds(np.linspace(0,1,num_plot_variation+1))[1:]
+        
+        # Marker shapes
+        sfm = ['s'] * num_plot_variation
+        
+        # If True, every other FIP dataset will be plotted with hollow markers
+        hollow_and_full = False       
+
+        # Plot to show variability?
+        variability = True
+        
+    # Plot the variability in the 160^3 simulations
+    elif mat == '41000_variation':
+        
+        # Names to use for figure legend
+        names = ['~41,000 grains x %d SVEs' % num_plot_variation]
+        
+        # Locations of FIP files
+        locs = locats_Al7075_convergence[1]
+        
+        # Number of columns for figure legend
+        plot_col = 1
+        
+        # Marker colors
+        cfm = plt_cols.cm.Blues(np.linspace(0,1,num_plot_variation+1))[1:]
+        
+        # Marker shapes
+        sfm = ['o'] * num_plot_variation
+        
+        # If True, every other FIP dataset will be plotted with hollow markers
+        hollow_and_full = False       
+
+        # Plot to show variability?
+        variability = True    
+
+    # Plot the variability in the 200^3 simulations
+    elif mat == '80000_variation':
+        
+        # Names to use for figure legend
+        names = ['~80,000 grains x %d SVEs' % num_plot_variation]
+        
+        # Locations of FIP files
+        locs = locats_Al7075_convergence[2]
+        
+        # Number of columns for figure legend
+        plot_col = 1
+        
+        # Marker colors
+        cfm = plt_cols.cm.Greens(np.linspace(0,1,num_plot_variation+1))[1:]
+        
+        # Marker shapes
+        sfm = ['^'] * num_plot_variation
+        
+        # If True, every other FIP dataset will be plotted with hollow markers
+        hollow_and_full = False       
+
+        # Plot to show variability?
+        variability = True 
+        
+    else:
+        raise ValueError('Please check "mat" variable!') 
+
+
+    if variability:
+        # Execute this section if interested in variability across FIP EVDs
+        fip_list = []
+        
+        # Number of FIPs to extract from each pickle file
+        num_fips_extract = 1500
+        
+        # Keep track of file nomenclature
+        grain_per_SVE = int(mat.split('_')[0])
+
+        # Define filename
+        file_name_4 = os.path.join(base_directory, 'compiled_from_individ_SVE_FIP_data_%d.p' % grain_per_SVE)
+        
+        # If this file already exists, simply read it
+        if os.path.exists(file_name_4):
+        
+            h4 = open(file_name_4, 'rb')
+            fips_temp = p.load(h4)
+            h4.close()
+            fip_list = fips_temp
+        
+        # Otherwise, read in some number of highest FIPs from each file and plot each
+        else:
+        
+            for vv in range(num_plot_variation):
+                temp_fs_fips = read_FIPs_from_single_SVE(locs, vv, num_fips_extract)
+                
+                fip_list.append(temp_fs_fips)
+                
+            file_name_4 = os.path.join(base_directory, 'compiled_from_individ_SVE_FIP_data_%d.p' % grain_per_SVE)
+            h4 = open(file_name_4, 'wb')
+            p.dump(fip_list, h4)
+            h4.close()
+
+    else:
+ 
+        # Number of total FIPs to extract from simulation files
+        num_fips_extract = 1500
+        
+        if num_fips_extract < num_fips_plot:
+            raise ValueError('More FIPs are desired for plots than are to be extracted! Please edit "num_fips_plot" and/or "num_fips_extract" !')
+       
+
+        # If compiled list of FIPs exists, simply read it in; otherwise, compile FIPs
+        fip_list = []
+        for pickle_location in locs:
+        
+            # Define name of file with compiled FIPs for each simulation folder
+            file_name_1 = os.path.basename(os.path.split(pickle_location)[1])
+            compiled_fips_loc = os.path.join(os.getcwd(), 'compiled_%s_%s_%s.p' % (FIP_type, averaging_type, file_name_1))
+
+            # If this file already exists, read in the FIPs
+            if os.path.exists(compiled_fips_loc):
+                h1 = open(compiled_fips_loc,'rb')
+                fip_list.append(p.load(h1, encoding = 'latin1'))
+                h1.close()
+
+            # Otherwise, read and store FIPs for quicker plotting
+            else:
+                # print(pickle_location)
+                temp_fs_fips = read_pickled_SBA_FIPs(pickle_location, num_fips_extract, FIP_type, averaging_type)
+                # temp_fs_fips = read_FIPs_from_single_SVE(pickle_location)
+                print('Reading SBA surface and subsurface FIPs')
+                temp_fs_fips = np.array(temp_fs_fips)
+
+                if len(temp_fs_fips) > 0:
+                    fip_list.append(temp_fs_fips)
+                    
+                h2 = open(compiled_fips_loc,'wb')
+                p.dump(temp_fs_fips,h2)
+                h2.close()
+
+
+
+    # Create list of appended FIPs to plot
+    fip_list_to_plot = []
+    for item in fip_list:
+        fip_list_to_plot.append(item[0:num_fips_plot])
+    
+    
+    
+    
+    # Print the number of FIPs to be plotted
+    for item in fip_list_to_plot:
+        # print len(item)
+        print('Length of FIP list: ' + str(len(item)))
+
+
+    # Option to plot either Frechet or Gumbel distribution with band-averaged FIPs
+    if plt_type == 'frechet':
+        fig, r_squared_values, slope_values, y_intercept_values, highest_FIP = plot_gumbels(fip_list_to_plot, plt_type, cfm, sfm, mat, plot_col, variability, names, hollow_and_full, xlabel = "ln(FS FIPs)")
+    elif plt_type == 'gumbel':
+        fig, r_squared_values, slope_values, y_intercept_values, highest_FIP = plot_gumbels(fip_list_to_plot, plt_type, cfm, sfm, mat, plot_col, variability, names, hollow_and_full, xlabel = "FIP")        
+    
+    
+    if save_fig:
+        if variability:
+            plt.savefig("%s_EVD_%s_%s_%d_%s_num_SVEs_%d" % (FIP_type, averaging_type, plt_type, num_fips_plot, mat, num_plot_variation), dpi=fig.dpi)
+        else:
+            plt.savefig("%s_EVD_%s_%s_%d_%s" % (FIP_type, averaging_type, plt_type, num_fips_plot, mat), dpi=fig.dpi)
+        
+    # Write r-squared values to .csv file 
+    fname = os.path.join(os.getcwd(),'r_squared_%s_%s_%s_%d_%s.csv' % (plt_type, FIP_type, averaging_type, num_fips_plot, mat))    
+    write_r = open(fname,'w')
+    for i in range(len(r_squared_values)):
+        write_r.write(str(r_squared_values[i]) + ',' + str(slope_values[i]) + ',' + str(y_intercept_values[i])+ ',' + str(highest_FIP[i]) + '\n')
+    write_r.close()
+    print('SBA FIP r-squared value for ' + plt_type + ' is ' + str(np.average(r_squared_values)) + ' for ' + str(num_fips_plot) + ' FIPs') 
+   
+def prettify_frame(ax):
+    ax.tick_params(which='both', direction='out', pad=pad_dist*.75)
+    ax.yaxis.set_ticks_position('left')
+    ax.xaxis.set_ticks_position('bottom')
+    for axis in ['top','bottom','left','right']:
+        ax.spines[axis].set_linewidth(tick_widths)
+        ax.spines[axis].set_visible(True)
+        ax.spines[axis].set_color('k')
+    ax.xaxis.set_tick_params(which='major', width=tick_widths,length=tick_lens,color='k')
+    ax.xaxis.set_tick_params(which='minor', width=tick_widths/2.0,length=tick_lens*.6,color='k')
+    ax.yaxis.set_tick_params(which='major', width=tick_widths,length=tick_lens,color='k')
+    ax.yaxis.set_tick_params(which='minor', width=tick_widths/2.0,length=tick_lens*.6,color='k')
+    temp_list = [ax.title, ax.xaxis.label, ax.yaxis.label] + ax.get_xticklabels() + ax.get_yticklabels()
+    for item in temp_list:
+        item.set_fontsize(font_size * 1.25)
+        item.set_color("k")
+    try:
+        for item in ax.get_legend().get_texts():
+            item.set_fontsize(font_size * 1)
+            item.set_color("k")
+    except:
+        print("not doing legend text...")
+    ax.set_frame_on(True)
+    plt.tight_layout()
+    
+def plot_gumbels(data, plt_type, cfm, sfm, mat, plot_col, variability, names = None, hollow_and_full = False, xlabel = "", plot_lin = False):
+    
+    if names is None:
+        names = [str(i) for i in range(len(data))]
+
+    # Plot all FIPs for comparison
+    
+    if mat == '7500_grain_compare_shape' or mat == '41000_grain_compare_shape':
+        fig = plt.figure(facecolor="white", figsize=(6, 4), dpi=1200)
+    elif mat == '7500_variation' or mat == '41000_variation' or mat == '80000_variation' or mat == 'Al7075_convergence':  
+        fig = plt.figure(facecolor="white", figsize=(6, 4), dpi=1200)
+    else:
+        fig = plt.figure(facecolor="white", figsize=(6, 4), dpi=1200)
+        
+    ax = plt.axes()
+    plt.grid(linewidth = 0.5)
+    ax.set_axisbelow(True)
+    d_min = None
+    d_max = None
+    min_ys = 0
+    max_ys = 0
+    
+    r_squared_values     = []
+    slope_values         = []
+    y_intercept_values   = []
+    highest_FIP          = []
+    
+    for i, d_orig in enumerate(data):
+
+        d = np.sort(d_orig)
+        
+        # If FIPs are to be fit to the Frechet EVD, take the log of each FIP
+        if plt_type == 'frechet':
+            for yyy in range(len(d)):
+                d[yyy] = np.log(d[yyy])
+        
+        # Estimate probability; see references below that explain this equation
+        ys = (np.arange(len(d)) + 1 - 0.3) / (len(d) + 0.4)
+        ys = -np.log(-np.log(ys))
+        
+        min_ys = min(min_ys, ys[0])
+        max_ys = max(max_ys, ys[-1])
+        colormat = cm.rainbow(np.linspace(0, 1, 4))
+
+        # If true, plot every other set of FIPs as hollow for easy visual comparison
+        if hollow_and_full:
+        
+            if i % 2 == 0:
+                ax.scatter(d, ys, c=cfm[i], label=names[i], marker=sfm[i], alpha=0.75, linewidths=0.5)
+            
+            elif i % 2 == 1:
+                ax.scatter(d, ys, c='white', edgecolors=cfm[i], label=names[i], marker=sfm[i], alpha=0.75, linewidths=1)       
+        
+        # Otherwise, plot all markers as solid color
+        else:
+        
+            if variability:
+                    if i == len(data) - 1:
+                        ax.scatter(d, ys, c=cfm[i], label=names[0], marker=sfm[i], alpha=0.75, linewidths=0.5, s = 50)
+                    else:
+                        ax.scatter(d, ys, c=cfm[i], marker=sfm[i], alpha=0.75, linewidths=0.5, s = 50)
+                        
+            else:
+                ax.scatter(d, ys, c=cfm[i], marker=sfm[i], label=names[i], alpha=0.75, linewidths=0.5, s = 50) 
+           
+        # If plot_lin is true, a line of best fit is also plotted
+        slope, intercept, r_value, p_value, std_err = ss.linregress(np.ndarray.tolist(d),np.ndarray.tolist(ys))
+        if plt_type == 'frechet':
+            interp_points = np.asarray([np.min(d), np.max(d)])
+        else:
+            interp_points = np.asarray([np.min(d)-np.min(d)*0.03, np.max(d)])
+        # interp_points = np.asarray([np.min(d), np.max(d)])
+        interp_ys = interp_points * slope + intercept
+        if plot_lin:
+            ax.plot(interp_points, interp_ys, c='k', linewidth=1, linestyle='--')
+        # print(len(d))
+        print("slope: %e, intercept: %e, r^2: %f" % (slope, intercept, r_value**2))
+        
+        if d_max is None or np.max(d) > d_max:
+            d_max = np.max(d)
+        if d_min is None or np.min(d) < d_min:
+            d_min = np.min(d)
+        r_squared_values.append(r_value**2)
+        slope_values.append(slope)
+        highest_FIP.append(max(d_orig))
+        y_intercept_values.append(intercept)
+        
+    prettify_frame(ax)
+     
+    if mat == '7500_variation' or mat == '41000_variation' or mat == '80000_variation' or mat == 'Al7075_convergence':
+        plt.xlim(0.44e-2, 1.25e-2)
+        plt.legend(loc='lower right', fontsize='11', ncol=plot_col, framealpha=1)
+        # plt.legend()
+    elif mat == '41000_grain_compare_shape' or mat == '7500_grain_compare_shape':
+        plt.xlim(0.32e-2, 1.0e-2)
+        plt.legend(loc='lower right', fontsize='8', ncol=plot_col, framealpha=1)
+    
+    plt.ylabel("$-\mathrm{ln}(-\mathrm{ln}(p))$", fontsize='10')
+    plt.xlabel(xlabel, fontsize='10')
+    
+
+    # Specify upper limit on plot; edit this as necessary 
+    if len(d) == 100:
+        plt.ylim(np.floor(min_ys), 5.5)
+    elif len(d) == 150 or len(d) == 200:
+        plt.ylim(np.floor(min_ys), 6)
+    elif len(d) == 250:
+        plt.ylim(np.floor(min_ys), 7)
+    else:
+        plt.ylim(np.floor(min_ys), 5)
+        
+    if plt_type == 'gumbel':
+        plt.ticklabel_format(style='sci', axis='x', scilimits=(0,0), useMathText = True, useOffset=False)
+    elif plt_type == 'frechet':
+        plt.ticklabel_format(style='sci', axis='x', scilimits=(0,0), useMathText = True)
+        
+   
+    plt.tight_layout()
+    return fig, r_squared_values, slope_values, y_intercept_values, highest_FIP
+    
+def main(plt_type = 'gumbel'):
+
+    # Specify folder which contains all of the simulation batch folders
+    # IMPORTANT: this directory should contain the locations specified at the top of this python script, NOT the individual folders with the instantiations!
+    # This script goes through EACH ONE of the folders specified and extracts the relevant information for plotting purposes
+    
+    # directory = os.path.dirname(DIR_LOC) + '\\PRISMS-Fatigue_tutorial'
+    
+    directory = os.path.join(DIR_LOC, r'plots')
+
+    # Specify which 'material' to plot, i.e., which combinations of microsturcture folders
+    # Please see the top of the "plot_FIPS" function
+    mat_type = ['7500_variation', '41000_variation', '80000_variation', 'Al7075_convergence', '7500_grain_compare_shape', '41000_grain_compare_shape']
+    
+    for mat in mat_type:
+        # Specify number of SVEs from which to plot FIPs to investigate FIP EVD variability
+        if mat == '7500_variation':
+            num_plot_variation = 22
+            n_fip_plot = 100
+        elif mat == '41000_variation':
+            num_plot_variation = 4
+            n_fip_plot = 100
+        elif mat == '80000_variation':
+            num_plot_variation = 2
+            n_fip_plot = 100
+        elif mat == 'Al7075_convergence':
+            num_plot_variation = 1
+            n_fip_plot = 100
+        else:
+            num_plot_variation = 1
+            n_fip_plot = 50
+
+        # Specify which FIP to import
+        FIP_type = 'FS_FIP'
+        
+        # Specify which volume averaging scheme to import. By default, the sub-band averaged (SBA) FIPs are used
+        # IMPORTANT: this will fail if the FIPs have not yet been averaged in the desired manner (see 'volume_average_FIPs.py' script)
+        # Options: 'sub_band', 'band', and 'grain'
+        averaging_type = 'sub_band'
+        
+        # Specify how many of the highest FIPs should be plotted
+        # n_fip_plot = 25
+
+        # Specify whether FIPs should be fit to the "gumbel" or "frechet" EVD
+        # plt_type = 'frechet'
+        
+        # Call function to plot FIPs
+        plot_FIPS(directory, plt_type, mat, n_fip_plot, FIP_type, averaging_type, num_plot_variation, save_fig = True)
+    
+if __name__ == "__main__":
+    main()

--- a/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_new_1st_highest_FIP_grain_orientations.py
+++ b/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_new_1st_highest_FIP_grain_orientations.py
@@ -1,0 +1,699 @@
+import pandas as pd
+import random
+import os
+import numpy as np
+import xlrd
+import shutil
+
+# SCRIPT TO EDIT ORIENTATIONS OF NEAREST NEIGHBOR GRAINS CENTERED ABOUT THE GRAIN THAT MANIFESTS THE 1ST HIGHEST FIP
+
+# This script will create new orientation_#.txt files for PRISMS-Plasticity simulations. The orientation of a single or multiple grains will be altered by drawing from other grain orientations from the 160,000 grain microstructure that is not part of the two cropped regions in Section 6 of the associated manuscript. This script will do this for the microstructure cropped about the grain that manifests the 1st highest FIP in the 160,00 grain microstructure. 
+
+# IMPORTANT NOTE: The microstructures simulated in the associated manuscript were generated using this script and those files are available to users. A subsequent execution of this code will create NEW AND UNIQUE microstructure files since the orientations of grain is overwritten by selecting grain orientations from the uncropped region of the 160,000 grain microstructure AT RANDOM. However, the SAME grains will be affected since they were selected based on grain size.
+
+# Get name of directory that contains the PRISMS-Fatigue scripts, i.e., this script
+DIR_LOC = os.path.dirname(os.path.abspath(__file__))
+
+def flatten(d):
+    return {i for b in [[i] if not isinstance(i, list) else flatten(i) for i in d] for i in b}
+
+def create_new_microstructure_files_1st_highest_FIP_grain():
+
+    # Read in orientations from cropped 72^3 microstructure about the 1st highest FIP grain from the 160,000 grain microstructure
+    fname1 = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\orientations_0.txt')
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    # Read in original list of grain orientations, from which we will randomly sample
+    original_orientations = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\orientations_0_original_250_250_250.txt'), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    # Define grain number that manifests the 1st highest FIP in the 160,000 grain microstructure AFTER it is cropped
+    highest_FIP_grain = 2423 # Indexed at 0 !
+
+    ''' Read in list of neighbors '''
+    # https://stackoverflow.com/questions/61885456/how-to-read-each-row-of-excel-file-into-a-list-so-as-to-make-whole-data-a-list-o
+    
+    listoflist = []
+    
+    # Make sure the workbook below has no header line
+    workbook1 = xlrd.open_workbook(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\neighbors_list_no_top_row.xlsx'))
+    
+    b = workbook1.sheet_by_index(0)
+    
+    for i in range(0,b.nrows):
+        rli = []
+        for j in range(0,b.ncols):
+            if b.cell_value(i,j) != '':
+                rli.append(b.cell_value(i,j))
+        listoflist.append(rli)
+
+    neighbor_list = []   
+    for kk in listoflist:
+        neighbor_list.append([int(pp) for pp in kk[2:]])
+
+    first_nearest_neighbors = [rr - 1 for rr in neighbor_list[highest_FIP_grain]]
+
+    # GRAIN NUMBERS INDEXED AT 0 !!! 
+
+
+    ''' Find second nearest grains '''
+    second_nearest_neighbor_grains = []
+    for neighbors_1 in first_nearest_neighbors:
+        second_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+        
+    flat_second = list(flatten(second_nearest_neighbor_grains))
+
+    unique_second = []
+
+    for item4 in flat_second:
+        if item4 not in first_nearest_neighbors:
+            unique_second.append(item4)
+
+    # Remove highest FIP grain from list
+    unique_second.remove(highest_FIP_grain)
+
+
+    ''' Find third nearest grains '''
+    third_nearest_neighbor_grains = []
+
+    for neighbors_2 in unique_second:
+        third_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_2]]   )
+        
+    flat_third = list(flatten(third_nearest_neighbor_grains))
+        
+    unique_third = []
+
+    for item5 in flat_third:
+        if (item5 not in unique_second) and (item5 not in first_nearest_neighbors):
+            unique_third.append(item5)
+
+
+    ''' Find fourth nearest grains '''
+    fourth_nearest_neighbor_grains = []
+
+    for neighbors_3 in unique_third:
+        fourth_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_3]]   )
+        
+    flat_fourth = list(flatten(fourth_nearest_neighbor_grains))
+        
+    unique_fourth = []
+
+    for item6 in flat_fourth:
+        if (item6 not in unique_third) and (item6 not in unique_second) and (item6 not in first_nearest_neighbors):
+            unique_fourth.append(item6)
+
+
+    ''' Find fifth nearest grains '''
+    fifth_nearest_neighbor_grains = []
+
+    for neighbors_4 in unique_fourth:
+        fifth_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_4]]   )
+        
+    flat_fifth = list(flatten(fifth_nearest_neighbor_grains))
+        
+    unique_fifth = []
+
+    for item7 in flat_fifth:
+        if (item7 not in unique_fourth) and (item7 not in unique_third) and (item7 not in unique_second):
+            unique_fifth.append(item7)
+
+
+    # Print number of grains in each layer
+
+    print('Number of 1st nearest neighbors: %d' % len(first_nearest_neighbors))
+    print('Number of 2nd nearest neighbors: %d' % len(unique_second))
+    print('Number of 3rd nearest neighbors: %d' % len(unique_third))
+    print('Number of 4th nearest neighbors: %d' % len(unique_fourth))
+    print('Number of 5th nearest neighbors: %d' % len(unique_fifth))
+
+
+    ''' Visualization of grain layers : '''
+
+    Fname_vtk_loc = os.path.join(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\Output_FakeMatl_0.vtk'))
+    Fname_vtk_new = os.path.join(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\Output_FakeMatl_0_append_grain_layers.vtk'))
+
+    # Create copy of original .vtk file in case something goes wrong!
+    shutil.copy(Fname_vtk_loc, Fname_vtk_new)
+
+
+    vtk_first_part = []
+    with open(Fname_vtk_loc) as f:
+        for line in f.readlines():
+            vtk_first_part.append(line)
+            if 'EulerAngles' in line:
+                vtk_first_part.append('LOOKUP_TABLE default \n')
+                break
+    f.close()
+
+
+
+    # Get just lines with grain IDs
+    grain_IDs = vtk_first_part[24:-2]
+
+    # Convert line of grain IDs from string to list of ints
+    first_line = [int(s) for s in grain_IDs[0].split() if s.isdigit()]
+
+    f_vtk = open(Fname_vtk_new,'a')
+
+    f_vtk.write('SCALARS layers int 1\n')
+    f_vtk.write('LOOKUP_TABLE default\n')
+
+    counter = 0
+
+    # Iterate through lines of grain IDs from .vtk file
+    for kk in grain_IDs:
+
+        # Get grain IDs
+        temp_grain_IDs = [int(s) for s in kk.split() if s.isdigit()]
+        
+        # Iterate through each grain ID
+        for jj in temp_grain_IDs:
+
+            if (jj-1) in first_nearest_neighbors:
+                f_vtk.write(' 1')
+            elif (jj-1) in unique_second:
+                f_vtk.write(' 2')
+            elif (jj-1) in unique_third:
+                f_vtk.write(' 3')
+            elif (jj-1) in unique_fourth:
+                f_vtk.write(' 4')
+            elif (jj-1) in unique_fifth:
+                f_vtk.write(' 5')
+            else:
+                f_vtk.write(' 0')
+        
+        # Write new line
+        f_vtk.write('\n')
+
+    f_vtk.close()
+
+
+
+
+
+
+
+
+    # We can sample from the first ~2,000 grains since these are entirely different than the first and second nearest neighbor grains for grain 84853 of the original 250^3 microstructure! 
+
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Change orientations of first nearest neighbors '''
+    
+    num_create = 5
+    for ii in range(num_create):
+        
+        # Create num_create of modified orientations.txt files that change the orientations of the grains that neighbor the highest FIP grain (84853, indexed at 1)
+        
+        # Generate list of random integers between 0 and 2000; length of first nearest neighbors
+        first_while = True
+        while first_while:
+            randomlist_first = []
+            for i in range(len(first_nearest_neighbors)):
+                n = random.randint(1,2000)
+                randomlist_first.append(n)
+
+            # Check for duplicates
+            first_while = any(randomlist_first.count(x) > 1 for x in randomlist_first)
+
+        # Overwrite orientations
+        for yy in range(len(first_nearest_neighbors)):
+            df1.loc[first_nearest_neighbors[yy],1:3] = original_orientations.loc[randomlist_first[yy],1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Change orientations of second nearest neighbors '''
+
+    num_create = 5
+    for ii in range(num_create):
+
+        # Generate list of random integers between 0 and 2000; length of first nearest neighbors
+        second_while = True
+        while second_while:
+            randomlist_second = []
+            for i in range(len(unique_second)):
+                n = random.randint(1,2000)
+                randomlist_second.append(n)
+
+            # Check for duplicates
+            second_while = any(randomlist_second.count(x) > 1 for x in randomlist_second)
+
+        # Overwrite orientations
+        for yy in range(len(unique_second)):
+            df1.loc[unique_second[yy],1:3] = original_orientations.loc[randomlist_second[yy],1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_second_NN_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Change orientations of third nearest neighbors '''
+
+    num_create = 5
+    for ii in range(num_create):
+
+        # Generate list of random integers between 0 and 2000; length of first nearest neighbors
+        third_while = True
+        while third_while:
+            randomlist_third = []
+            for i in range(len(unique_third)):
+                n = random.randint(1,2000)
+                randomlist_third.append(n)
+
+            # Check for duplicates
+            third_while = any(randomlist_third.count(x) > 1 for x in randomlist_third)
+
+        # Overwrite orientations
+        for yy in range(len(unique_third)):
+            df1.loc[unique_third[yy],1:3] = original_orientations.loc[randomlist_third[yy],1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_third_NN_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Change orientations of fourth nearest neighbors '''
+
+    num_create = 5
+    for ii in range(num_create):
+
+        # Generate list of random integers between 0 and 2000; length of first nearest neighbors
+        fourth_while = True
+        while fourth_while:
+            # randomlist_fourth = []
+            # for i in range(len(unique_fourth)):
+            #     n = random.randint(1,5000)
+            #     randomlist_fourth.append(n)
+            
+            randomlist_fourth = random.sample(range(2000),len(unique_fourth))
+
+            # Check for duplicates
+            fourth_while = any(randomlist_fourth.count(x) > 1 for x in randomlist_fourth)
+
+        # Overwrite orientations
+        for yy in range(len(unique_fourth)):
+            df1.loc[unique_fourth[yy],1:3] = original_orientations.loc[randomlist_fourth[yy],1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_fourth_NN_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Change orientations of fifth nearest neighbors '''
+
+    num_create = 5
+    for ii in range(num_create):
+        
+        print('On file number %d' % ii)
+        
+        # Generate list of random integers between 0 and 2000; length of first nearest neighbors
+        fifth_while = True
+        while fifth_while:
+            # randomlist_fifth = []
+            # for i in range(len(unique_fifth)):
+                # n = random.randint(1,5000)
+                # randomlist_fifth.append(n)
+                
+            randomlist_fifth = random.sample(range(2000),len(unique_fifth))
+
+            # Check for duplicates
+            fifth_while = any(randomlist_fifth.count(x) > 1 for x in randomlist_fifth)
+
+        # Overwrite orientations
+        for yy in range(len(unique_fifth)):
+            df1.loc[unique_fifth[yy],1:3] = original_orientations.loc[randomlist_fifth[yy],1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_fifth_NN_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+
+
+    ''' Extract volumes... '''
+    df3 = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\cropped_72_72_72_first_chunk.csv'), index_col = False)
+    num_elems = df3[['NumElements']].to_numpy(dtype=float)
+
+    # Find largest grain in each layer..
+    # First layer:
+
+    largest_first_index = np.where(num_elems[first_nearest_neighbors] == max((num_elems[first_nearest_neighbors])))[0][0]
+    largest_first = first_nearest_neighbors[largest_first_index]
+
+    # Second layer:
+
+    largest_second_index = np.where(num_elems[unique_second] == max((num_elems[unique_second])))[0][0]
+    # unique_second[49]
+    largest_second = unique_second[largest_second_index]
+    # num_elems[largest_second]
+    # This is grain number 3485, indexed at 1 !
+
+
+    # Third layer:
+
+    largest_third_index = np.where(num_elems[unique_third] == max((num_elems[unique_third])))[0][0]
+    # unique_third[104]
+    largest_third = unique_third[largest_third_index]
+    # num_elems[largest_third]
+    # This is grain number 3399, indexed at 1 !
+
+
+    # Fourth layer:
+
+    largest_fourth_index = np.where(num_elems[unique_fourth] == max((num_elems[unique_fourth])))[0][0]
+    # unique_fourth[15]
+    largest_fourth = unique_fourth[largest_fourth_index]
+    # num_elems[largest_fourth]
+    # This is grain number 4179, indexed at 1 !
+
+
+    # Fifth layer:
+
+    largest_fifth_index = np.where(num_elems[unique_fifth] == max((num_elems[unique_fifth])))[0][0]
+    # unique_fifth[341]
+    largest_fifth = unique_fifth[largest_fifth_index]
+    # num_elems[largest_fifth]
+    # This is grain number 3325, indexed at 1 !
+
+
+
+
+
+
+    # Modify one grain that neighbors the grain with the largest FIP.
+    # First, the grain that is largest, which is grain number 1775 (indexed at 1) after cropping
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 10
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[largest_first,1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_largest_neighbor_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    # Second, the grain that shares the most surface area, which is grain number 1853 (indexed at 1) after cropping
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 10
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[1852,1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_largest_shared_area_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Modify the orientation of the largest grain in layers 2 thru 5 ! '''
+
+    num_create = 5
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[largest_second,1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_2nd_layer_%d.txt' % ii), sep = ' ', index = False)
+
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[largest_third,1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_3rd_layer_%d.txt' % ii), sep = ' ', index = False)
+        
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[largest_fourth,1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_4th_layer_%d.txt' % ii), sep = ' ', index = False)
+
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[largest_fifth,1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_5th_layer_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+
+
+
+    ''' Mid January 2021; need to create 45 additional files that contain:
+        Changed orientations for layers 3, 4, and 5; 5 sets for each one, where we change the orientation of
+        1) The top 5 largest grains
+        2) The 5% largest grains
+        3) the 20% largest grains
+        --> I.e., do not pick grains at random! '''
+        
+        
+    # So first, let's sort the grains in each layer by volume:
+
+    # "num_elems" contains the number of elements in each grain
+
+    # This is how we found the largest grain in the third layer:
+
+    
+    # Number of elements in each grain of layer 3
+    layer_3_num_elems_per_grain = num_elems[unique_third].astype(int).transpose()[0]
+    layer_3_info = np.vstack([layer_3_num_elems_per_grain, unique_third])
+
+    # Now sort by the number of elements in each grain!
+    layer_3_sorted_info = layer_3_info.transpose()[layer_3_info.transpose()[:,0].argsort()][::-1]
+
+    # List the grains of interest EXCLUDING the highest grain since we already changed this...!
+    layer_3_largest_5_grains   = layer_3_sorted_info.transpose()[1][1:5]
+    layer_3_largest_grain      = layer_3_sorted_info.transpose()[1][0]
+    
+    temp11 = int(np.rint(len(layer_3_sorted_info)*0.05))
+    layer_3_largest_5_perc_grains   = layer_3_sorted_info.transpose()[1][1:temp11]
+    
+    temp22 = int(np.rint(len(layer_3_sorted_info)*0.2))
+    layer_3_largest_20_perc_grains  =layer_3_sorted_info.transpose()[1][1:temp22]
+
+
+    # List the grains that were changed (not including the largest) that SHOULD be changed back to what they originall were
+    
+    layer_3_change_back_5 = layer_3_sorted_info.transpose()[1][5:]
+    
+    layer_3_change_back_largest_5_perc_grains  = layer_3_sorted_info.transpose()[1][temp11:]
+    layer_3_change_back_largest_20_perc_grains = layer_3_sorted_info.transpose()[1][temp22:]
+
+   
+    # Now let's modify and create new text files...!
+    
+    # BRILLIANT IDEA!:
+    # Read in the orientations of the grains that were changed the first time around and set all other grains back to original orientations!
+    
+    # BETTER YET: read in the files we created last time around and CHANGE the last X amount of grains back to their original orientations! 
+      
+
+    ''' Change orientations of third nearest neighbors '''
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+
+
+    for ii in range(num_create):
+
+        # Read in previous modified orientations
+        modified_orients_top_5          = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_third_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        modified_orients_top_5_percent  = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_third_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        modified_orients_top_20_percent = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_third_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        
+        # Get orientation of largest grain changed previously...
+        
+        modified_orients_get_largest_ori = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_3rd_layer_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')  
+        
+
+        # Change BACK the orientations of interest!!
+        modified_orients_top_5.loc[layer_3_change_back_5,1:3] = df1.loc[layer_3_change_back_5,1:3]
+        modified_orients_top_5.loc[layer_3_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_3_largest_grain,1:3]
+        
+        modified_orients_top_5_percent.loc[layer_3_change_back_largest_5_perc_grains,1:3] = df1.loc[layer_3_change_back_largest_5_perc_grains,1:3]
+        modified_orients_top_5_percent.loc[layer_3_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_3_largest_grain,1:3]
+        
+        modified_orients_top_20_percent.loc[layer_3_change_back_largest_20_perc_grains,1:3] = df1.loc[layer_3_change_back_largest_20_perc_grains,1:3]
+        modified_orients_top_20_percent.loc[layer_3_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_3_largest_grain,1:3]
+        
+        
+        # Write to new text file
+        modified_orients_top_5.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\1st_highest_FIP_modify_largest_5_grains_in_third_layer_%d.txt' % ii), sep = ' ', index = False)
+        
+        modified_orients_top_5_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\1st_highest_FIP_modify_largest_5_percent_grains_in_third_layer_%d.txt'  % ii), sep = ' ', index = False)
+        
+        modified_orients_top_20_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\1st_highest_FIP_modify_largest_20_percent_grains_in_third_layer_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    # Sweet! Now repeat for layer 4:
+
+        
+        # Number of elements in each grain of layer 4
+        layer_4_num_elems_per_grain = num_elems[unique_fourth].astype(int).transpose()[0]
+        layer_4_info = np.vstack([layer_4_num_elems_per_grain, unique_fourth])
+
+        # Now sort by the number of elements in each grain!
+        layer_4_sorted_info = layer_4_info.transpose()[layer_4_info.transpose()[:,0].argsort()][::-1]
+
+        # List the grains of interest EXCLUDING the highest grain since we already changed this...!
+        layer_4_largest_5_grains   = layer_4_sorted_info.transpose()[1][1:5]
+        layer_4_largest_grain      = layer_4_sorted_info.transpose()[1][0]
+        
+        temp44 = int(np.rint(len(layer_4_sorted_info)*0.05))
+        layer_4_largest_5_perc_grains   = layer_4_sorted_info.transpose()[1][1:temp44]
+        
+        temp55 = int(np.rint(len(layer_4_sorted_info)*0.2))
+        layer_4_largest_20_perc_grains  =layer_4_sorted_info.transpose()[1][1:temp55]
+
+
+        # List the grains that were changed (not including the largest) that SHOULD be changed back to what they originall were
+        
+        layer_4_change_back_5 = layer_4_sorted_info.transpose()[1][5:]
+        
+        layer_4_change_back_largest_5_perc_grains  = layer_4_sorted_info.transpose()[1][temp44:]
+        layer_4_change_back_largest_20_perc_grains = layer_4_sorted_info.transpose()[1][temp55:]
+
+
+    ''' Change orientations of fourth nearest neighbors '''
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+
+    for ii in range(num_create):
+
+        # Read in previous modified orientations
+        modified_orients_top_5          = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_fourth_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')   
+        modified_orients_top_5_percent  = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_fourth_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip') 
+        modified_orients_top_20_percent = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_fourth_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        
+        modified_orients_get_largest_ori = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_4th_layer_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')  
+
+        # Change BACK the orientations of interest!!
+        modified_orients_top_5.loc[layer_4_change_back_5,1:3] = df1.loc[layer_4_change_back_5,1:3]
+        modified_orients_top_5.loc[layer_4_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_4_largest_grain,1:3]
+        
+        modified_orients_top_5_percent.loc[layer_4_change_back_largest_5_perc_grains,1:3] = df1.loc[layer_4_change_back_largest_5_perc_grains,1:3]
+        modified_orients_top_5_percent.loc[layer_4_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_4_largest_grain,1:3]
+        
+        modified_orients_top_20_percent.loc[layer_4_change_back_largest_20_perc_grains,1:3] = df1.loc[layer_4_change_back_largest_20_perc_grains,1:3]
+        modified_orients_top_20_percent.loc[layer_4_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_4_largest_grain,1:3]
+        
+        
+        # Write to new text file
+        modified_orients_top_5.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\1st_highest_FIP_modify_largest_5_grains_in_fourth_layer_%d.txt' % ii), sep = ' ', index = False)
+        
+        modified_orients_top_5_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\1st_highest_FIP_modify_largest_5_percent_grains_in_fourth_layer_%d.txt' % ii), sep = ' ', index = False)
+        
+        modified_orients_top_20_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\1st_highest_FIP_modify_largest_20_percent_grains_in_fourth_layer_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    # Sweet! Now repeat for layer 5:
+
+        
+        # Number of elements in each grain of layer 5
+        layer_5_num_elems_per_grain = num_elems[unique_fifth].astype(int).transpose()[0]
+        layer_5_info = np.vstack([layer_5_num_elems_per_grain, unique_fifth])
+
+        # Now sort by the number of elements in each grain!
+        layer_5_sorted_info = layer_5_info.transpose()[layer_5_info.transpose()[:,0].argsort()][::-1]
+
+        # List the grains of interest EXCLUDING the highest grain since we already changed this...!
+        layer_5_largest_5_grains   = layer_5_sorted_info.transpose()[1][1:5]
+        layer_5_largest_grain      = layer_5_sorted_info.transpose()[1][0]
+        
+        temp77 = int(np.rint(len(layer_5_sorted_info)*0.05))
+        layer_5_largest_5_perc_grains   = layer_5_sorted_info.transpose()[1][1:temp77]
+        
+        temp88 = int(np.rint(len(layer_5_sorted_info)*0.2))
+        layer_5_largest_20_perc_grains  = layer_5_sorted_info.transpose()[1][1:temp88]
+
+
+        # List the grains that were changed (not including the largest) that SHOULD be changed back to what they originall were
+        
+        layer_5_change_back_5 = layer_5_sorted_info.transpose()[1][5:]
+        
+        layer_5_change_back_largest_5_perc_grains  = layer_5_sorted_info.transpose()[1][temp77:]
+        layer_5_change_back_largest_20_perc_grains = layer_5_sorted_info.transpose()[1][temp88:]
+
+
+    ''' Change orientations of fourth nearest neighbors '''
+    df1 = pd.read_csv(fname1, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+
+    for ii in range(num_create):
+
+        # Read in previous modified orientations
+        modified_orients_top_5          = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_fifth_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')   
+        modified_orients_top_5_percent  = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_fifth_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip') 
+        modified_orients_top_20_percent = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientations_fifth_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        
+        modified_orients_get_largest_ori = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_5th_layer_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')  
+
+        # Change BACK the orientations of interest!!
+        modified_orients_top_5.loc[layer_5_change_back_5,1:3] = df1.loc[layer_5_change_back_5,1:3]
+        modified_orients_top_5.loc[layer_5_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_5_largest_grain,1:3]
+        
+        modified_orients_top_5_percent.loc[layer_5_change_back_largest_5_perc_grains,1:3] = df1.loc[layer_5_change_back_largest_5_perc_grains,1:3]
+        modified_orients_top_5_percent.loc[layer_5_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_5_largest_grain,1:3]
+        
+        modified_orients_top_20_percent.loc[layer_5_change_back_largest_20_perc_grains,1:3] = df1.loc[layer_5_change_back_largest_20_perc_grains,1:3]
+        modified_orients_top_20_percent.loc[layer_5_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_5_largest_grain,1:3]
+        
+        
+        # Write to new text file
+        modified_orients_top_5.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\1st_highest_FIP_modify_largest_5_grains_in_fifth_layer_%d.txt' % ii), sep = ' ', index = False)
+        
+        modified_orients_top_5_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\1st_highest_FIP_modify_largest_5_percent_grains_in_fifth_layer_%d.txt'  % ii), sep = ' ', index = False)
+        
+        modified_orients_top_20_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\Cropped_around_1st_highest_FIP_microstructure_data\1st_highest_FIP_modify_largest_20_percent_grains_in_fifth_layer_%d.txt' % ii), sep = ' ', index = False)
+
+def main():
+    # Create new files for cropped microstructure about grain that manifests the 1st highest FIP in the 160,000 grain microstructure
+    create_new_microstructure_files_1st_highest_FIP_grain()
+
+if __name__ == "__main__":
+    main()

--- a/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_new_3rd_highest_FIP_grain_orientations.py
+++ b/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_new_3rd_highest_FIP_grain_orientations.py
@@ -1,0 +1,699 @@
+import pandas as pd
+import random
+import os
+import numpy as np
+import xlrd
+import shutil
+
+# SCRIPT TO EDIT ORIENTATIONS OF NEAREST NEIGHBOR GRAINS CENTERED ABOUT THE GRAIN THAT MANIFESTS THE 3RD HIGHEST FIP
+
+# This script will create new orientation_#.txt files for PRISMS-Plasticity simulations. The orientation of a single or multiple grains will be altered by drawing from other grain orientations from the 160,000 grain microstructure that is not part of the two cropped regions in Section 6 of the associated manuscript. This script will do this for the microstructure cropped about the grain that manifests the 3rd highest FIP in the 160,00 grain microstructure. 
+
+# IMPORTANT NOTE: The microstructures simulated in the associated manuscript were generated using this script and those files are available to users. A subsequent execution of this code will create NEW AND UNIQUE microstructure files since the orientations of grain is overwritten by selecting grain orientations from the uncropped region of the 160,000 grain microstructure AT RANDOM. However, the SAME grains will be affected since they were selected based on grain size.
+
+# Get name of directory that contains the PRISMS-Fatigue scripts, i.e., this script
+DIR_LOC = os.path.dirname(os.path.abspath(__file__))
+
+def flatten(d):
+    return {i for b in [[i] if not isinstance(i, list) else flatten(i) for i in d] for i in b}
+
+def create_new_microstructure_files_3rd_highest_FIP_grain():
+
+    # Read in orientations from cropped 72^3 microstructure about the 3rd highest FIP grain from the 160,000 grain microstructure
+    fname2 = os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\orientations_0.txt')
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    # Read in original list of grain orientations, from which we will randomly sample
+    original_orientations = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\orientations_0_original_250_250_250.txt'), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    # Define grain number that manifests the 3rd highest FIP in the 160,000 grain microstructure AFTER it is cropped
+    highest_FIP_grain = 555 # Indexed at 0 !
+
+    ''' Read in list of neighbors '''
+    # https://stackoverflow.com/questions/61885456/how-to-read-each-row-of-excel-file-into-a-list-so-as-to-make-whole-data-a-list-o
+    
+    listoflist = []
+    
+    # Make sure the workbook below has no header line
+    workbook1 = xlrd.open_workbook(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\neighbor_list_third_grain.xlsx'))
+    
+    b = workbook1.sheet_by_index(0)
+    
+    for i in range(0,b.nrows):
+        rli = []
+        for j in range(0,b.ncols):
+            if b.cell_value(i,j) != '':
+                rli.append(b.cell_value(i,j))
+        listoflist.append(rli)
+
+    neighbor_list = []   
+    for kk in listoflist:
+        neighbor_list.append([int(pp) for pp in kk[2:]])
+
+    first_nearest_neighbors = [rr - 1 for rr in neighbor_list[highest_FIP_grain]]
+
+    # GRAIN NUMBERS INDEXED AT 0 !!! 
+
+
+    ''' Find second nearest grains '''
+    second_nearest_neighbor_grains = []
+    for neighbors_1 in first_nearest_neighbors:
+        second_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_1]]   )
+        
+    flat_second = list(flatten(second_nearest_neighbor_grains))
+
+    unique_second = []
+
+    for item4 in flat_second:
+        if item4 not in first_nearest_neighbors:
+            unique_second.append(item4)
+
+    # Remove highest FIP grain from list
+    unique_second.remove(highest_FIP_grain)
+
+
+    ''' Find third nearest grains '''
+    third_nearest_neighbor_grains = []
+
+    for neighbors_2 in unique_second:
+        third_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_2]]   )
+        
+    flat_third = list(flatten(third_nearest_neighbor_grains))
+        
+    unique_third = []
+
+    for item5 in flat_third:
+        if (item5 not in unique_second) and (item5 not in first_nearest_neighbors):
+            unique_third.append(item5)
+
+
+    ''' Find fourth nearest grains '''
+    fourth_nearest_neighbor_grains = []
+
+    for neighbors_3 in unique_third:
+        fourth_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_3]]   )
+        
+    flat_fourth = list(flatten(fourth_nearest_neighbor_grains))
+        
+    unique_fourth = []
+
+    for item6 in flat_fourth:
+        if (item6 not in unique_third) and (item6 not in unique_second) and (item6 not in first_nearest_neighbors):
+            unique_fourth.append(item6)
+
+
+    ''' Find fifth nearest grains '''
+    fifth_nearest_neighbor_grains = []
+
+    for neighbors_4 in unique_fourth:
+        fifth_nearest_neighbor_grains.append(  [rr - 1 for rr in neighbor_list[neighbors_4]]   )
+        
+    flat_fifth = list(flatten(fifth_nearest_neighbor_grains))
+        
+    unique_fifth = []
+
+    for item7 in flat_fifth:
+        if (item7 not in unique_fourth) and (item7 not in unique_third) and (item7 not in unique_second):
+            unique_fifth.append(item7)
+
+
+    # Print number of grains in each layer
+
+    print('Number of 1st nearest neighbors: %d' % len(first_nearest_neighbors))
+    print('Number of 2nd nearest neighbors: %d' % len(unique_second))
+    print('Number of 3rd nearest neighbors: %d' % len(unique_third))
+    print('Number of 4th nearest neighbors: %d' % len(unique_fourth))
+    print('Number of 5th nearest neighbors: %d' % len(unique_fifth))
+
+
+    ''' Visualization of grain layers : '''
+
+    Fname_vtk_loc = os.path.join(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\cropped_72_72_72_third_grain.vtk'))
+    Fname_vtk_new = os.path.join(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\cropped_72_72_72_third_grain_append_grain_layers.vtk'))
+
+    # Create copy of original .vtk file in case something goes wrong!
+    shutil.copy(Fname_vtk_loc, Fname_vtk_new)
+
+
+    vtk_first_part = []
+    with open(Fname_vtk_loc) as f:
+        for line in f.readlines():
+            vtk_first_part.append(line)
+            if 'EulerAngles' in line:
+                vtk_first_part.append('LOOKUP_TABLE default \n')
+                break
+    f.close()
+
+
+
+    # Get just lines with grain IDs
+    grain_IDs = vtk_first_part[24:-2]
+
+    # Convert line of grain IDs from string to list of ints
+    first_line = [int(s) for s in grain_IDs[0].split() if s.isdigit()]
+
+    f_vtk = open(Fname_vtk_new,'a')
+
+    f_vtk.write('SCALARS layers int 1\n')
+    f_vtk.write('LOOKUP_TABLE default\n')
+
+    counter = 0
+
+    # Iterate through lines of grain IDs from .vtk file
+    for kk in grain_IDs:
+
+        # Get grain IDs
+        temp_grain_IDs = [int(s) for s in kk.split() if s.isdigit()]
+        
+        # Iterate through each grain ID
+        for jj in temp_grain_IDs:
+
+            if (jj-1) in first_nearest_neighbors:
+                f_vtk.write(' 1')
+            elif (jj-1) in unique_second:
+                f_vtk.write(' 2')
+            elif (jj-1) in unique_third:
+                f_vtk.write(' 3')
+            elif (jj-1) in unique_fourth:
+                f_vtk.write(' 4')
+            elif (jj-1) in unique_fifth:
+                f_vtk.write(' 5')
+            else:
+                f_vtk.write(' 0')
+        
+        # Write new line
+        f_vtk.write('\n')
+
+    f_vtk.close()
+
+
+
+
+
+
+
+
+    # We can sample from the first ~2,000 grains since these are entirely different than the first and second nearest neighbor grains for grain 84853 of the original 250^3 microstructure! 
+
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Change orientations of first nearest neighbors '''
+    
+    num_create = 5
+    for ii in range(num_create):
+        
+        # Create num_create of modified orientations.txt files that change the orientations of the grains that neighbor the highest FIP grain (84853, indexed at 1)
+        
+        # Generate list of random integers between 0 and 2000; length of first nearest neighbors
+        first_while = True
+        while first_while:
+            randomlist_first = []
+            for i in range(len(first_nearest_neighbors)):
+                n = random.randint(1,1500)
+                randomlist_first.append(n)
+
+            # Check for duplicates
+            first_while = any(randomlist_first.count(x) > 1 for x in randomlist_first)
+
+        # Overwrite orientations
+        for yy in range(len(first_nearest_neighbors)):
+            df1.loc[first_nearest_neighbors[yy],1:3] = original_orientations.loc[randomlist_first[yy],1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_1st_NN_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Change orientations of second nearest neighbors '''
+
+    num_create = 5
+    for ii in range(num_create):
+
+        # Generate list of random integers between 0 and 2000; length of first nearest neighbors
+        second_while = True
+        while second_while:
+            randomlist_second = []
+            for i in range(len(unique_second)):
+                n = random.randint(1,2000)
+                randomlist_second.append(n)
+
+            # Check for duplicates
+            second_while = any(randomlist_second.count(x) > 1 for x in randomlist_second)
+
+        # Overwrite orientations
+        for yy in range(len(unique_second)):
+            df1.loc[unique_second[yy],1:3] = original_orientations.loc[randomlist_second[yy],1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_2nd_NN_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Change orientations of third nearest neighbors '''
+
+    num_create = 5
+    for ii in range(num_create):
+
+        # Generate list of random integers between 0 and 2000; length of first nearest neighbors
+        third_while = True
+        while third_while:
+            randomlist_third = []
+            for i in range(len(unique_third)):
+                n = random.randint(1,2000)
+                randomlist_third.append(n)
+
+            # Check for duplicates
+            third_while = any(randomlist_third.count(x) > 1 for x in randomlist_third)
+
+        # Overwrite orientations
+        for yy in range(len(unique_third)):
+            df1.loc[unique_third[yy],1:3] = original_orientations.loc[randomlist_third[yy],1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_3rd_NN_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Change orientations of fourth nearest neighbors '''
+
+    num_create = 5
+    for ii in range(num_create):
+
+        # Generate list of random integers between 0 and 2000; length of first nearest neighbors
+        fourth_while = True
+        while fourth_while:
+            # randomlist_fourth = []
+            # for i in range(len(unique_fourth)):
+            #     n = random.randint(1,5000)
+            #     randomlist_fourth.append(n)
+            
+            randomlist_fourth = random.sample(range(2000),len(unique_fourth))
+
+            # Check for duplicates
+            fourth_while = any(randomlist_fourth.count(x) > 1 for x in randomlist_fourth)
+
+        # Overwrite orientations
+        for yy in range(len(unique_fourth)):
+            df1.loc[unique_fourth[yy],1:3] = original_orientations.loc[randomlist_fourth[yy],1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_4th_NN_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Change orientations of fifth nearest neighbors '''
+
+    num_create = 5
+    for ii in range(num_create):
+        
+        print('On file number %d' % ii)
+        
+        # Generate list of random integers between 0 and 2000; length of first nearest neighbors
+        fifth_while = True
+        while fifth_while:
+            # randomlist_fifth = []
+            # for i in range(len(unique_fifth)):
+                # n = random.randint(1,5000)
+                # randomlist_fifth.append(n)
+                
+            randomlist_fifth = random.sample(range(2000),len(unique_fifth))
+
+            # Check for duplicates
+            fifth_while = any(randomlist_fifth.count(x) > 1 for x in randomlist_fifth)
+
+        # Overwrite orientations
+        for yy in range(len(unique_fifth)):
+            df1.loc[unique_fifth[yy],1:3] = original_orientations.loc[randomlist_fifth[yy],1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_5th_NN_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+
+
+    ''' Extract volumes... '''
+    df3 = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\cropped_72_72_72_third_grain_first_chunk.csv'), index_col = False)
+    num_elems = df3[['NumElements']].to_numpy(dtype=float)
+
+    # Find largest grain in each layer..
+    # First layer:
+
+    largest_first_index = np.where(num_elems[first_nearest_neighbors] == max((num_elems[first_nearest_neighbors])))[0][0]
+    largest_first = first_nearest_neighbors[largest_first_index]
+
+    # Second layer:
+
+    largest_second_index = np.where(num_elems[unique_second] == max((num_elems[unique_second])))[0][0]
+    # unique_second[49]
+    largest_second = unique_second[largest_second_index]
+    # num_elems[largest_second]
+    # This is grain number 3485, indexed at 1 !
+
+
+    # Third layer:
+
+    largest_third_index = np.where(num_elems[unique_third] == max((num_elems[unique_third])))[0][0]
+    # unique_third[104]
+    largest_third = unique_third[largest_third_index]
+    # num_elems[largest_third]
+    # This is grain number 3399, indexed at 1 !
+
+
+    # Fourth layer:
+
+    largest_fourth_index = np.where(num_elems[unique_fourth] == max((num_elems[unique_fourth])))[0][0]
+    # unique_fourth[15]
+    largest_fourth = unique_fourth[largest_fourth_index]
+    # num_elems[largest_fourth]
+    # This is grain number 4179, indexed at 1 !
+
+
+    # Fifth layer:
+
+    largest_fifth_index = np.where(num_elems[unique_fifth] == max((num_elems[unique_fifth])))[0][0]
+    # unique_fifth[341]
+    largest_fifth = unique_fifth[largest_fifth_index]
+    # num_elems[largest_fifth]
+    # This is grain number 3325, indexed at 1 !
+
+
+
+
+
+
+    # Modify one grain that neighbors the grain with the largest FIP.
+    # First, the grain that is largest
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 10
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[first_nearest_neighbors[4],1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_largest_neighbor_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    # Second, the grain that shares the most surface area
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 10
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[3963,1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_largest_shared_area_1st_layer_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+    ''' Modify the orientation of the largest grain in layers 2 thru 5 ! '''
+
+    num_create = 5
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[largest_second,1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_2nd_layer_%d.txt' % ii), sep = ' ', index = False)
+
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[largest_third,1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_3rd_layer_%d.txt' % ii), sep = ' ', index = False)
+        
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[largest_fourth,1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_4th_layer_%d.txt' % ii), sep = ' ', index = False)
+
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+    for ii in range(num_create):
+
+        n = random.randint(1,2000)
+
+        # Overwrite orientations
+
+        df1.loc[largest_fifth,1:3] = original_orientations.loc[n,1:3]
+        
+        # Write to new text file
+        df1.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_5th_layer_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+
+
+
+    ''' Mid January 2021; need to create 45 additional files that contain:
+        Changed orientations for layers 3, 4, and 5; 5 sets for each one, where we change the orientation of
+        1) The top 5 largest grains
+        2) The 5% largest grains
+        3) the 20% largest grains
+        --> I.e., do not pick grains at random! '''
+        
+        
+    # So first, let's sort the grains in each layer by volume:
+
+    # "num_elems" contains the number of elements in each grain
+
+    # This is how we found the largest grain in the third layer:
+
+    
+    # Number of elements in each grain of layer 3
+    layer_3_num_elems_per_grain = num_elems[unique_third].astype(int).transpose()[0]
+    layer_3_info = np.vstack([layer_3_num_elems_per_grain, unique_third])
+
+    # Now sort by the number of elements in each grain!
+    layer_3_sorted_info = layer_3_info.transpose()[layer_3_info.transpose()[:,0].argsort()][::-1]
+
+    # List the grains of interest EXCLUDING the highest grain since we already changed this...!
+    layer_3_largest_5_grains   = layer_3_sorted_info.transpose()[1][1:5]
+    layer_3_largest_grain      = layer_3_sorted_info.transpose()[1][0]
+    
+    temp11 = int(np.rint(len(layer_3_sorted_info)*0.05))
+    layer_3_largest_5_perc_grains   = layer_3_sorted_info.transpose()[1][1:temp11]
+    
+    temp22 = int(np.rint(len(layer_3_sorted_info)*0.2))
+    layer_3_largest_20_perc_grains  =layer_3_sorted_info.transpose()[1][1:temp22]
+
+
+    # List the grains that were changed (not including the largest) that SHOULD be changed back to what they originall were
+    
+    layer_3_change_back_5 = layer_3_sorted_info.transpose()[1][5:]
+    
+    layer_3_change_back_largest_5_perc_grains  = layer_3_sorted_info.transpose()[1][temp11:]
+    layer_3_change_back_largest_20_perc_grains = layer_3_sorted_info.transpose()[1][temp22:]
+
+   
+    # Now let's modify and create new text files...!
+    
+    # BRILLIANT IDEA!:
+    # Read in the orientations of the grains that were changed the first time around and set all other grains back to original orientations!
+    
+    # BETTER YET: read in the files we created last time around and CHANGE the last X amount of grains back to their original orientations! 
+      
+
+    ''' Change orientations of third nearest neighbors '''
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+
+
+    for ii in range(num_create):
+
+        # Read in previous modified orientations
+        modified_orients_top_5          = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_3rd_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        modified_orients_top_5_percent  = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_3rd_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        modified_orients_top_20_percent = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_3rd_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        
+        # Get orientation of largest grain changed previously...
+        
+        modified_orients_get_largest_ori = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_3rd_layer_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        
+
+        # Change BACK the orientations of interest!!
+        modified_orients_top_5.loc[layer_3_change_back_5,1:3] = df1.loc[layer_3_change_back_5,1:3]
+        modified_orients_top_5.loc[layer_3_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_3_largest_grain,1:3]
+        
+        modified_orients_top_5_percent.loc[layer_3_change_back_largest_5_perc_grains,1:3] = df1.loc[layer_3_change_back_largest_5_perc_grains,1:3]
+        modified_orients_top_5_percent.loc[layer_3_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_3_largest_grain,1:3]
+        
+        modified_orients_top_20_percent.loc[layer_3_change_back_largest_20_perc_grains,1:3] = df1.loc[layer_3_change_back_largest_20_perc_grains,1:3]
+        modified_orients_top_20_percent.loc[layer_3_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_3_largest_grain,1:3]
+        
+        
+        # Write to new text file
+        modified_orients_top_5.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\3rd_highest_FIP_modify_largest_5_grains_in_third_layer_%d.txt' % ii), sep = ' ', index = False)
+        
+        modified_orients_top_5_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\3rd_highest_FIP_modify_largest_5_percent_grains_in_third_layer_%d.txt'  % ii), sep = ' ', index = False)
+        
+        modified_orients_top_20_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\3rd_highest_FIP_modify_largest_20_percent_grains_in_third_layer_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    # Sweet! Now repeat for layer 4:
+
+        
+        # Number of elements in each grain of layer 4
+        layer_4_num_elems_per_grain = num_elems[unique_fourth].astype(int).transpose()[0]
+        layer_4_info = np.vstack([layer_4_num_elems_per_grain, unique_fourth])
+
+        # Now sort by the number of elements in each grain!
+        layer_4_sorted_info = layer_4_info.transpose()[layer_4_info.transpose()[:,0].argsort()][::-1]
+
+        # List the grains of interest EXCLUDING the highest grain since we already changed this...!
+        layer_4_largest_5_grains   = layer_4_sorted_info.transpose()[1][1:5]
+        layer_4_largest_grain      = layer_4_sorted_info.transpose()[1][0]
+        
+        temp44 = int(np.rint(len(layer_4_sorted_info)*0.05))
+        layer_4_largest_5_perc_grains   = layer_4_sorted_info.transpose()[1][1:temp44]
+        
+        temp55 = int(np.rint(len(layer_4_sorted_info)*0.2))
+        layer_4_largest_20_perc_grains  =layer_4_sorted_info.transpose()[1][1:temp55]
+
+
+        # List the grains that were changed (not including the largest) that SHOULD be changed back to what they originall were
+        
+        layer_4_change_back_5 = layer_4_sorted_info.transpose()[1][5:]
+        
+        layer_4_change_back_largest_5_perc_grains  = layer_4_sorted_info.transpose()[1][temp44:]
+        layer_4_change_back_largest_20_perc_grains = layer_4_sorted_info.transpose()[1][temp55:]
+
+
+    ''' Change orientations of fourth nearest neighbors '''
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+
+    for ii in range(num_create):
+
+        # Read in previous modified orientations
+        modified_orients_top_5          = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_4th_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        modified_orients_top_5_percent  = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_4th_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        modified_orients_top_20_percent = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_4th_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        
+        modified_orients_get_largest_ori = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_4th_layer_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+        # Change BACK the orientations of interest!!
+        modified_orients_top_5.loc[layer_4_change_back_5,1:3] = df1.loc[layer_4_change_back_5,1:3]
+        modified_orients_top_5.loc[layer_4_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_4_largest_grain,1:3]
+        
+        modified_orients_top_5_percent.loc[layer_4_change_back_largest_5_perc_grains,1:3] = df1.loc[layer_4_change_back_largest_5_perc_grains,1:3]
+        modified_orients_top_5_percent.loc[layer_4_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_4_largest_grain,1:3]
+        
+        modified_orients_top_20_percent.loc[layer_4_change_back_largest_20_perc_grains,1:3] = df1.loc[layer_4_change_back_largest_20_perc_grains,1:3]
+        modified_orients_top_20_percent.loc[layer_4_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_4_largest_grain,1:3]
+        
+        
+        # Write to new text file
+        modified_orients_top_5.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\3rd_highest_FIP_modify_largest_5_grains_in_fourth_layer_%d.txt' % ii), sep = ' ', index = False)
+        
+        modified_orients_top_5_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\3rd_highest_FIP_modify_largest_5_percent_grains_in_fourth_layer_%d.txt'  % ii), sep = ' ', index = False)
+        
+        modified_orients_top_20_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\3rd_highest_FIP_modify_largest_20_percent_grains_in_fourth_layer_%d.txt' % ii), sep = ' ', index = False)
+
+
+
+    # Sweet! Now repeat for layer 5:
+
+        
+        # Number of elements in each grain of layer 5
+        layer_5_num_elems_per_grain = num_elems[unique_fifth].astype(int).transpose()[0]
+        layer_5_info = np.vstack([layer_5_num_elems_per_grain, unique_fifth])
+
+        # Now sort by the number of elements in each grain!
+        layer_5_sorted_info = layer_5_info.transpose()[layer_5_info.transpose()[:,0].argsort()][::-1]
+
+        # List the grains of interest EXCLUDING the highest grain since we already changed this...!
+        layer_5_largest_5_grains   = layer_5_sorted_info.transpose()[1][1:5]
+        layer_5_largest_grain      = layer_5_sorted_info.transpose()[1][0]
+        
+        temp77 = int(np.rint(len(layer_5_sorted_info)*0.05))
+        layer_5_largest_5_perc_grains   = layer_5_sorted_info.transpose()[1][1:temp77]
+        
+        temp88 = int(np.rint(len(layer_5_sorted_info)*0.2))
+        layer_5_largest_20_perc_grains  = layer_5_sorted_info.transpose()[1][1:temp88]
+
+
+        # List the grains that were changed (not including the largest) that SHOULD be changed back to what they originall were
+        
+        layer_5_change_back_5 = layer_5_sorted_info.transpose()[1][5:]
+        
+        layer_5_change_back_largest_5_perc_grains  = layer_5_sorted_info.transpose()[1][temp77:]
+        layer_5_change_back_largest_20_perc_grains = layer_5_sorted_info.transpose()[1][temp88:]
+
+
+    ''' Change orientations of fourth nearest neighbors '''
+    df1 = pd.read_csv(fname2, delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+    num_create = 5
+
+    for ii in range(num_create):
+
+        # Read in previous modified orientations
+        modified_orients_top_5          = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_5th_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        modified_orients_top_5_percent  = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_5th_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        modified_orients_top_20_percent = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientations_5th_NN_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+        
+        modified_orients_get_largest_ori = pd.read_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\modified_orientation_largest_neighbor_in_5th_layer_%d.txt' % ii), delimiter = ' ', header = None, skiprows = 1, float_precision='round_trip')
+
+        # Change BACK the orientations of interest!!
+        modified_orients_top_5.loc[layer_5_change_back_5,1:3] = df1.loc[layer_5_change_back_5,1:3]
+        modified_orients_top_5.loc[layer_5_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_5_largest_grain,1:3]
+        
+        modified_orients_top_5_percent.loc[layer_5_change_back_largest_5_perc_grains,1:3] = df1.loc[layer_5_change_back_largest_5_perc_grains,1:3]
+        modified_orients_top_5_percent.loc[layer_5_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_5_largest_grain,1:3]
+        
+        modified_orients_top_20_percent.loc[layer_5_change_back_largest_20_perc_grains,1:3] = df1.loc[layer_5_change_back_largest_20_perc_grains,1:3]
+        modified_orients_top_20_percent.loc[layer_5_largest_grain,1:3] = modified_orients_get_largest_ori.loc[layer_5_largest_grain,1:3]
+        
+        
+        # Write to new text file
+        modified_orients_top_5.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\3rd_highest_FIP_modify_largest_5_grains_in_fifth_layer_%d.txt' % ii), sep = ' ', index = False)
+        
+        modified_orients_top_5_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\3rd_highest_FIP_modify_largest_5_percent_grains_in_fifth_layer_%d.txt'  % ii), sep = ' ', index = False)
+        
+        modified_orients_top_20_percent.to_csv(os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\Cropped_around_3rd_highest_FIP_microstructure_data\3rd_highest_FIP_modify_largest_20_percent_grains_in_fifth_layer_%d.txt' % ii), sep = ' ', index = False)
+
+def main():
+    # Create new files for cropped microstructure about grain that manifests the 3rd highest FIP in the 160,000 grain microstructure
+    create_new_microstructure_files_3rd_highest_FIP_grain()
+
+if __name__ == "__main__":
+    main()

--- a/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_stress_strain.py
+++ b/applications/effects_of_sample_size_and_grain_neighborhood/PRISMS_FIP_convergence_stress_strain.py
@@ -1,0 +1,213 @@
+import os
+import numpy as np
+import sys
+import pandas as pd
+import operator
+import glob
+import pickle as p
+import csv
+import shutil
+import matplotlib
+import matplotlib.pyplot as plt
+import matplotlib.pylab as plt_cols
+import matplotlib.cm as cm
+import re
+import glob
+
+# Get name of directory that contains the PRISMS-Fatigue scripts
+DIR_LOC = os.path.dirname(os.path.abspath(__file__))
+
+def extract_stress_strain_curves_section_3():
+
+    # Define directories
+    directories = [os.path.join(DIR_LOC, r'Section_3\stress_strain\90^3_cubic_fully_periodic_equiaxed\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_3\stress_strain\90^3_cubic_fully_periodic_elongated\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_3\stress_strain\90^3_random_fully_periodic_equiaxed_additional_5\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_3\stress_strain\90^3_random_fully_periodic_elongated\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_3\stress_strain\90^3_rolled_fully_periodic_equiaxed\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_3\stress_strain\90^3_rolled_fully_periodic_elongated\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_3\stress_strain\160^3_cubic_fully_periodic_equiaxed\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_3\stress_strain\160^3_cubic_fully_periodic_elongated\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_3\stress_strain\160^3_random_fully_periodic_equiaxed_additional_5\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_3\stress_strain\160^3_random_fully_periodic_elongated\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_3\stress_strain\160^3_rolled_fully_periodic_equiaxed\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_3\stress_strain\160^3_rolled_fully_periodic_elongated\_Random_equiaxed_0')]
+                   
+    # Define where to save plots
+    store_dirr = os.path.join(DIR_LOC, r'plots')
+    os.chdir(store_dirr)   
+    
+    # Initialize empty arrays
+    all_strain_data = []
+    all_stress_data = []
+
+    for directory in directories:
+
+        file_dirr = os.path.join(directory, 'stressstrain.txt')
+        
+        # Read in data using pandas module
+        data2 = pd.read_csv(file_dirr, index_col = False, delimiter = "\t")
+
+        # Get average of strain in Z 
+        strain_z_temp = data2['Exx'].to_numpy()
+        strain_z_temp = np.insert(strain_z_temp, 0, 0, axis=0)
+        
+        # Get average of stress in Z 
+        stress_z_temp = data2['Txx'].to_numpy()
+        stress_z_temp = np.insert(stress_z_temp, 0, 0, axis=0)
+        
+        all_strain_data.append(strain_z_temp)
+        all_stress_data.append(stress_z_temp)
+
+
+    
+    # Plot stress-strain curves
+    
+    colorss = ['r', 'r', 'b', 'b', 'g', 'g']
+    linestyless = ['-', ':', '-', ':', '-', ':',]
+    labells = ['Cubic Equiaxed', 'Cubic Elongated', 'Random Equiaxed', 'Random Elongated', 'Rolled Equiaxed', 'Rolled Elongated']
+    
+    
+    fig = plt.figure(facecolor="white", figsize=(5.5, 3.666), dpi=1200)    
+    for kkk in np.arange(6):
+
+        plt.plot(all_strain_data[kkk], all_stress_data[kkk], color = colorss[kkk], linestyle = linestyless[kkk], label = labells[kkk], linewidth = 1.5)
+
+    plt.legend(framealpha = 1, fontsize = 8)
+    
+    # plt.show()
+    plt.ylabel('Stress [MPa]')   
+    plt.grid(True)
+    plt.xlabel('Strain')
+    plt.ticklabel_format(style = 'sci', axis='x', scilimits=(0,0), useMathText = True)        
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, '7500_grain_textured_stress_strain'))
+    plt.close()   
+    
+
+
+    colorss = ['r', 'r', 'b', 'b', 'g', 'g']
+    linestyless = ['-', ':', '-', ':', '-', ':',]
+    labells = ['Cubic Equiaxed', 'Cubic Elongated', 'Random Equiaxed', 'Random Elongated', 'Rolled Equiaxed', 'Rolled Elongated']
+    
+    
+    fig = plt.figure(facecolor="white", figsize=(5.5, 3.666), dpi=1200)    
+    for kkk in np.arange(6,12):
+
+        plt.plot(all_strain_data[kkk], all_stress_data[kkk], color = colorss[kkk-6], linestyle = linestyless[kkk-6], label = labells[kkk-6], linewidth = 1.5)
+
+    plt.legend(framealpha = 1, fontsize = 8)
+    
+    # plt.show()
+    plt.ylabel('Stress [MPa]')   
+    plt.grid(True)
+    plt.xlabel('Strain')
+    plt.ticklabel_format(style = 'sci', axis='x', scilimits=(0,0), useMathText = True)        
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, '41000_grain_textured_stress_strain'))
+    plt.close()       
+  
+def extract_stress_strain_curves_section_6():
+
+    # Define directories
+    directories = [os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\stress_strain\cropped_to_72_72_72_original_orientations\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\stress_strain\Layer5_Largest_20Percent_Grain\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\stress_strain\Layer5_Largest_20Percent_Grain\_Random_equiaxed_1'),
+                   os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\stress_strain\Layer5_Largest_20Percent_Grain\_Random_equiaxed_2'),
+                   os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\stress_strain\Layer5_Largest_20Percent_Grain\_Random_equiaxed_3'),
+                   os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_250^3\stress_strain\Layer5_Largest_20Percent_Grain\_Random_equiaxed_4'),
+                   os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\stress_strain\original_cropped_72^3_region_around_third_highest_FIP_grain\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\stress_strain\Layer5_Largest_20Percent_Grain\_Random_equiaxed_0'),
+                   os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\stress_strain\Layer5_Largest_20Percent_Grain\_Random_equiaxed_1'),
+                   os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\stress_strain\Layer5_Largest_20Percent_Grain\_Random_equiaxed_2'),
+                   os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\stress_strain\Layer5_Largest_20Percent_Grain\_Random_equiaxed_3'),
+                   os.path.join(DIR_LOC, r'Section_6\NeighborHoodEffects_cropped_third_highest_FIPs_250^3\stress_strain\Layer5_Largest_20Percent_Grain\_Random_equiaxed_4')]
+
+    # Define where to save plots
+    store_dirr = os.path.join(DIR_LOC, r'plots')
+    os.chdir(store_dirr)    
+    
+    # Plot stress-strain curves
+    all_strain_data = []
+    all_stress_data = []
+
+    for directory in directories:
+
+        file_dirr = os.path.join(directory, 'stressstrain.txt')
+        
+        # Read in data using pandas module
+        data2 = pd.read_csv(file_dirr, index_col = False, delimiter = "\t")
+
+        # Get average of strain in Z 
+        strain_z_temp = data2['Exx'].to_numpy()
+        strain_z_temp = np.insert(strain_z_temp, 0, 0, axis=0)
+        
+        
+        # Get average of stress in Z 
+        stress_z_temp = data2['Txx'].to_numpy()
+        stress_z_temp = np.insert(stress_z_temp, 0, 0, axis=0)
+        
+        all_strain_data.append(strain_z_temp)
+        all_stress_data.append(stress_z_temp)
+
+
+    
+    # Plot stress-strain curve    
+    
+    colorss = ['r', 'm', 'b', 'c', 'g', 'k']
+    linestyless = [':', '-.', '--', '-', ':', '-.']
+    labells = ['Original', 'Alt 1', 'Alt 2', 'Alt 3', 'Alt 4', 'Alt 5']
+    
+    
+    fig = plt.figure(facecolor="white", figsize=(5.5, 3.666), dpi=1200)    
+    for kkk in np.arange(6):
+    
+        plt.plot(all_strain_data[kkk], all_stress_data[kkk], color = colorss[kkk], marker = 'o', linestyle = linestyless[kkk], label = labells[kkk], linewidth = 1.5, markersize = 0.25)
+
+    plt.legend(framealpha = 1, fontsize = 8)
+    
+    # plt.show()
+    plt.ylabel('Stress [MPa]')   
+    plt.grid(True)
+    plt.xlabel('Strain')
+    plt.ticklabel_format(style = 'sci', axis='x', scilimits=(0,0), useMathText = True)        
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, '1st_highest_GOI_stress_strain_variation'))
+    plt.close()   
+    
+    
+
+    colorss = ['r', 'm', 'b', 'c', 'g', 'k']
+    linestyless = [':', '-.', '--', '-', ':', '-.']
+    labells = ['Original', 'Alt 1', 'Alt 2', 'Alt 3', 'Alt 4', 'Alt 5']
+    
+    fig = plt.figure(facecolor="white", figsize=(5.5, 3.666), dpi=1200)    
+    for kkk in np.arange(6,12):
+    
+        plt.plot(all_strain_data[kkk], all_stress_data[kkk], color = colorss[kkk-6], linestyle = linestyless[kkk-6], label = labells[kkk-6], linewidth = 1.5)
+
+    plt.legend(framealpha = 1, fontsize = 8)
+    
+    # plt.show()
+    plt.ylabel('Stress [MPa]')   
+    plt.grid(True)
+    plt.xlabel('Strain')
+    plt.ticklabel_format(style = 'sci', axis='x', scilimits=(0,0), useMathText = True)        
+    plt.tight_layout()
+    plt.savefig(os.path.join(store_dirr, '3rd_highest_GOI_stress_strain_variation'))
+    plt.close()       
+    
+  
+def main():
+    # Plot stress-strain curves for section 3
+    extract_stress_strain_curves_section_3()
+    
+    # Plot stress-strain curves for section 6
+    extract_stress_strain_curves_section_6()    
+
+if __name__ == "__main__":
+    main()
+
+
+
+

--- a/applications/effects_of_sample_size_and_grain_neighborhood/README.md
+++ b/applications/effects_of_sample_size_and_grain_neighborhood/README.md
@@ -1,0 +1,27 @@
+# Effects of sample size and grain neighborhood
+
+  These scripts are used to reproduce the analysis and plots for the manuscript entitled <B> Microstructure effects on the extreme value fatigue response of FCC metals and alloys: Effects of sample size and grain neighborhood</B>. In this work, the convergence of Fatigue Indicator Parameters as a function of sample size is investigated. Structural correlations between the highest FIPs and the grains that manifest these FIPs are then examined. Afterwards, the influence of the grain neighborhood on the extreme value fatigue response at hot-spot grains is studied.
+  
+  Users should first download the data set associated with this manuscript from Materials Commons at https://doi.org/10.13011/m3-31wm-h036. The data set consists of four folders entitled "Section_3", "Section_4", "Section_6", and "plots". These seven scripts should be placed in the same directory as these four folders. Users can then execute these scripts by opening a command prompt window, navigating to the directory with these folders and scripts, and executing the following command for each script:
+ 
+  ```bash
+  python PRISMS_FIP_convergence_1st_highest_FIP_analysis.py
+  ```
+  
+  Users can also execute these scripts in an interactive version of Python. First, execute the "ipython" command in a command prompt window to start an interactive session:
+  
+  ```bash
+  ipython
+  ```
+  
+  Then execute the following commands:
+  
+  ```python
+  import PRISMS_FIP_convergence_1st_highest_FIP_analysis as analyze_FIPs # Import the script
+  analyze_FIPs.main() # Execute the 'main()' function
+  ```
+  
+  Alternatively, users can import specific functions from the Python scripts, or copy-and-paste certain functions into the interactive Python session.
+  
+  
+  <B>Reference</B>:  K. S. Stopka, M. Yaghoobi, J. E. Allison, and D. L. McDowell. Microstructure effects on the extreme value fatigue response of FCC metals and alloys: Effects of sample size and grain neighborhood. (in review).

--- a/src/generate_microstructures.py
+++ b/src/generate_microstructures.py
@@ -1612,10 +1612,13 @@ def main():
     # Please see the references below for more information
     # WARNING!: If this is too low for very refined grains, this module will take a long time to run!
     # This is because it attempts to determine all UNIQUE combinations of some number of neighboring elements
-    # NOTE: Aim for ~8-10% of the average grain volume as the num_vox
+    
+    # NOTE: Aim for ~8-10% of the average grain volume as the num_vox, as specified below
+    # This is especially important when comparing microstructures with different grain sizes!
+    num_vox_percentage = 0.10
     
     # This line calculates num_vox to be 10% of the predicted average number of elements per grain
-    num_vox = np.around(np.prod(shape) / (np.prod(size) / ( (1.0/6.0) * np.pi * avg_grain_size ** 3  ) ) * 0.10).astype(int)
+    num_vox = np.around(np.prod(shape) / (np.prod(size) / ( (1.0/6.0) * np.pi * avg_grain_size ** 3  ) ) * num_vox_percentage).astype(int)
     
     # Comment out the above line and uncomment the line below to manually set the number of elements per sub-band
     # num_vox = 8


### PR DESCRIPTION
These scripts are associated with the third PRISMS-Fatigue manuscript entitled "Microstructure effects on the extreme value fatigue response of FCC metals and alloys: Effects of sample size and grain neighborhood".

Also, small change to generate_microstructures.py so that users can specify the volume percent of sub-bands as a percent of total grain volume. The default is set to 10%. This is especially important when comparing FIPs from microstructures with different grain sizes!